### PR TITLE
6.2.0 seller removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The following parameters are configurable for the API Client:
 | `retryOnTimeout` | `bool` | Whether to retry on request timeout.<br>*Default*: `true` |
 | `httpStatusCodesToRetry` | `array` | Http status codes to retry against.<br>*Default*: `408, 413, 429, 500, 502, 503, 504, 521, 522, 524` |
 | `httpMethodsToRetry` | `array` | Http methods to retry against.<br>*Default*: `'GET', 'PUT'` |
+| `basicAuthUserName` | `string` | The username to use with basic authentication |
+| `basicAuthPassword` | `string` | The password to use with basic authentication |
 
 The API client can be initialized as follows:
 
@@ -152,7 +154,6 @@ Here is the list of errors that the API might throw.
 * [Charges](/doc/controllers/charges.md)
 * [Recipients](/doc/controllers/recipients.md)
 * [Tokens](/doc/controllers/tokens.md)
-* [Sellers](/doc/controllers/sellers.md)
 * [Transactions](/doc/controllers/transactions.md)
 * [Transfers](/doc/controllers/transfers.md)
 

--- a/doc/client.md
+++ b/doc/client.md
@@ -14,6 +14,8 @@ The following parameters are configurable for the API Client:
 | `retryOnTimeout` | `bool` | Whether to retry on request timeout.<br>*Default*: `true` |
 | `httpStatusCodesToRetry` | `array` | Http status codes to retry against.<br>*Default*: `408, 413, 429, 500, 502, 503, 504, 521, 522, 524` |
 | `httpMethodsToRetry` | `array` | Http methods to retry against.<br>*Default*: `'GET', 'PUT'` |
+| `basicAuthUserName` | `string` | The username to use with basic authentication |
+| `basicAuthPassword` | `string` | The password to use with basic authentication |
 
 The API client can be initialized as follows:
 
@@ -33,15 +35,14 @@ The gateway for the SDK. This class acts as a factory for the Controllers and al
 
 | Name | Description |
 |  --- | --- |
+| getOrdersController() | Gets OrdersController |
 | getPlansController() | Gets PlansController |
 | getSubscriptionsController() | Gets SubscriptionsController |
 | getInvoicesController() | Gets InvoicesController |
-| getOrdersController() | Gets OrdersController |
 | getCustomersController() | Gets CustomersController |
 | getRecipientsController() | Gets RecipientsController |
 | getChargesController() | Gets ChargesController |
-| getTransfersController() | Gets TransfersController |
 | getTokensController() | Gets TokensController |
-| getSellersController() | Gets SellersController |
+| getTransfersController() | Gets TransfersController |
 | getTransactionsController() | Gets TransactionsController |
 

--- a/doc/controllers/charges.md
+++ b/doc/controllers/charges.md
@@ -12,17 +12,17 @@ $chargesController = $client->getChargesController();
 
 * [Update Charge Metadata](/doc/controllers/charges.md#update-charge-metadata)
 * [Update Charge Payment Method](/doc/controllers/charges.md#update-charge-payment-method)
-* [Get Charge Transactions](/doc/controllers/charges.md#get-charge-transactions)
-* [Update Charge Due Date](/doc/controllers/charges.md#update-charge-due-date)
-* [Get Charges](/doc/controllers/charges.md#get-charges)
-* [Capture Charge](/doc/controllers/charges.md#capture-charge)
 * [Update Charge Card](/doc/controllers/charges.md#update-charge-card)
-* [Get Charge](/doc/controllers/charges.md#get-charge)
 * [Get Charges Summary](/doc/controllers/charges.md#get-charges-summary)
-* [Retry Charge](/doc/controllers/charges.md#retry-charge)
-* [Cancel Charge](/doc/controllers/charges.md#cancel-charge)
 * [Create Charge](/doc/controllers/charges.md#create-charge)
+* [Get Charge Transactions](/doc/controllers/charges.md#get-charge-transactions)
+* [Capture Charge](/doc/controllers/charges.md#capture-charge)
+* [Get Charge](/doc/controllers/charges.md#get-charge)
+* [Cancel Charge](/doc/controllers/charges.md#cancel-charge)
+* [Get Charges](/doc/controllers/charges.md#get-charges)
 * [Confirm Payment](/doc/controllers/charges.md#confirm-payment)
+* [Update Charge Due Date](/doc/controllers/charges.md#update-charge-due-date)
+* [Retry Charge](/doc/controllers/charges.md#retry-charge)
 
 
 # Update Charge Metadata
@@ -163,147 +163,6 @@ $result = $chargesController->updateChargePaymentMethod($chargeId, $request);
 ```
 
 
-# Get Charge Transactions
-
-```php
-function getChargeTransactions(
-    string $chargeId,
-    ?int $page = null,
-    ?int $size = null
-): ListChargeTransactionsResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `string` | Template, Required | Charge Id |
-| `page` | `?int` | Query, Optional | Page number |
-| `size` | `?int` | Query, Optional | Page size |
-
-## Response Type
-
-[`ListChargeTransactionsResponse`](/doc/models/list-charge-transactions-response.md)
-
-## Example Usage
-
-```php
-$chargeId = 'charge_id8';
-
-$result = $chargesController->getChargeTransactions($chargeId);
-```
-
-
-# Update Charge Due Date
-
-Updates the due date from a charge
-
-```php
-function updateChargeDueDate(
-    string $chargeId,
-    UpdateChargeDueDateRequest $request,
-    ?string $idempotencyKey = null
-): GetChargeResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `string` | Template, Required | Charge Id |
-| `request` | [`UpdateChargeDueDateRequest`](/doc/models/update-charge-due-date-request.md) | Body, Required | Request for updating the due date |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetChargeResponse`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```php
-$chargeId = 'charge_id8';
-$request = new Models\UpdateChargeDueDateRequest;
-
-$result = $chargesController->updateChargeDueDate($chargeId, $request);
-```
-
-
-# Get Charges
-
-Lists all charges
-
-```php
-function getCharges(
-    ?int $page = null,
-    ?int $size = null,
-    ?string $code = null,
-    ?string $status = null,
-    ?string $paymentMethod = null,
-    ?string $customerId = null,
-    ?string $orderId = null,
-    ?\DateTime $createdSince = null,
-    ?\DateTime $createdUntil = null
-): ListChargesResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `page` | `?int` | Query, Optional | Page number |
-| `size` | `?int` | Query, Optional | Page size |
-| `code` | `?string` | Query, Optional | Filter for charge's code |
-| `status` | `?string` | Query, Optional | Filter for charge's status |
-| `paymentMethod` | `?string` | Query, Optional | Filter for charge's payment method |
-| `customerId` | `?string` | Query, Optional | Filter for charge's customer id |
-| `orderId` | `?string` | Query, Optional | Filter for charge's order id |
-| `createdSince` | `?\DateTime` | Query, Optional | Filter for the beginning of the range for charge's creation |
-| `createdUntil` | `?\DateTime` | Query, Optional | Filter for the end of the range for charge's creation |
-
-## Response Type
-
-[`ListChargesResponse`](/doc/models/list-charges-response.md)
-
-## Example Usage
-
-```php
-$result = $chargesController->getCharges();
-```
-
-
-# Capture Charge
-
-Captures a charge
-
-```php
-function captureCharge(
-    string $chargeId,
-    ?CreateCaptureChargeRequest $request = null,
-    ?string $idempotencyKey = null
-): GetChargeResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `string` | Template, Required | Charge id |
-| `request` | [`?CreateCaptureChargeRequest`](/doc/models/create-capture-charge-request.md) | Body, Optional | Request for capturing a charge |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetChargeResponse`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```php
-$chargeId = 'charge_id8';
-
-$result = $chargesController->captureCharge($chargeId);
-```
-
-
 # Update Charge Card
 
 Updates the card from a charge
@@ -400,33 +259,6 @@ $result = $chargesController->updateChargeCard($chargeId, $request);
 ```
 
 
-# Get Charge
-
-Get a charge from its id
-
-```php
-function getCharge(string $chargeId): GetChargeResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `string` | Template, Required | Charge id |
-
-## Response Type
-
-[`GetChargeResponse`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```php
-$chargeId = 'charge_id8';
-
-$result = $chargesController->getCharge($chargeId);
-```
-
-
 # Get Charges Summary
 
 ```php
@@ -455,67 +287,6 @@ function getChargesSummary(
 $status = 'status8';
 
 $result = $chargesController->getChargesSummary($status);
-```
-
-
-# Retry Charge
-
-Retries a charge
-
-```php
-function retryCharge(string $chargeId, ?string $idempotencyKey = null): GetChargeResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `string` | Template, Required | Charge id |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetChargeResponse`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```php
-$chargeId = 'charge_id8';
-
-$result = $chargesController->retryCharge($chargeId);
-```
-
-
-# Cancel Charge
-
-Cancel a charge
-
-```php
-function cancelCharge(
-    string $chargeId,
-    ?CreateCancelChargeRequest $request = null,
-    ?string $idempotencyKey = null
-): GetChargeResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `string` | Template, Required | Charge id |
-| `request` | [`?CreateCancelChargeRequest`](/doc/models/create-cancel-charge-request.md) | Body, Optional | Request for cancelling a charge |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetChargeResponse`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```php
-$chargeId = 'charge_id8';
-
-$result = $chargesController->cancelCharge($chargeId);
 ```
 
 
@@ -619,6 +390,173 @@ $result = $chargesController->createCharge($request);
 ```
 
 
+# Get Charge Transactions
+
+```php
+function getChargeTransactions(
+    string $chargeId,
+    ?int $page = null,
+    ?int $size = null
+): ListChargeTransactionsResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `string` | Template, Required | Charge Id |
+| `page` | `?int` | Query, Optional | Page number |
+| `size` | `?int` | Query, Optional | Page size |
+
+## Response Type
+
+[`ListChargeTransactionsResponse`](/doc/models/list-charge-transactions-response.md)
+
+## Example Usage
+
+```php
+$chargeId = 'charge_id8';
+
+$result = $chargesController->getChargeTransactions($chargeId);
+```
+
+
+# Capture Charge
+
+Captures a charge
+
+```php
+function captureCharge(
+    string $chargeId,
+    ?CreateCaptureChargeRequest $request = null,
+    ?string $idempotencyKey = null
+): GetChargeResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `string` | Template, Required | Charge id |
+| `request` | [`?CreateCaptureChargeRequest`](/doc/models/create-capture-charge-request.md) | Body, Optional | Request for capturing a charge |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetChargeResponse`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```php
+$chargeId = 'charge_id8';
+
+$result = $chargesController->captureCharge($chargeId);
+```
+
+
+# Get Charge
+
+Get a charge from its id
+
+```php
+function getCharge(string $chargeId): GetChargeResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `string` | Template, Required | Charge id |
+
+## Response Type
+
+[`GetChargeResponse`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```php
+$chargeId = 'charge_id8';
+
+$result = $chargesController->getCharge($chargeId);
+```
+
+
+# Cancel Charge
+
+Cancel a charge
+
+```php
+function cancelCharge(
+    string $chargeId,
+    ?CreateCancelChargeRequest $request = null,
+    ?string $idempotencyKey = null
+): GetChargeResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `string` | Template, Required | Charge id |
+| `request` | [`?CreateCancelChargeRequest`](/doc/models/create-cancel-charge-request.md) | Body, Optional | Request for cancelling a charge |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetChargeResponse`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```php
+$chargeId = 'charge_id8';
+
+$result = $chargesController->cancelCharge($chargeId);
+```
+
+
+# Get Charges
+
+Lists all charges
+
+```php
+function getCharges(
+    ?int $page = null,
+    ?int $size = null,
+    ?string $code = null,
+    ?string $status = null,
+    ?string $paymentMethod = null,
+    ?string $customerId = null,
+    ?string $orderId = null,
+    ?\DateTime $createdSince = null,
+    ?\DateTime $createdUntil = null
+): ListChargesResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `page` | `?int` | Query, Optional | Page number |
+| `size` | `?int` | Query, Optional | Page size |
+| `code` | `?string` | Query, Optional | Filter for charge's code |
+| `status` | `?string` | Query, Optional | Filter for charge's status |
+| `paymentMethod` | `?string` | Query, Optional | Filter for charge's payment method |
+| `customerId` | `?string` | Query, Optional | Filter for charge's customer id |
+| `orderId` | `?string` | Query, Optional | Filter for charge's order id |
+| `createdSince` | `?\DateTime` | Query, Optional | Filter for the beginning of the range for charge's creation |
+| `createdUntil` | `?\DateTime` | Query, Optional | Filter for the end of the range for charge's creation |
+
+## Response Type
+
+[`ListChargesResponse`](/doc/models/list-charges-response.md)
+
+## Example Usage
+
+```php
+$result = $chargesController->getCharges();
+```
+
+
 # Confirm Payment
 
 ```php
@@ -647,5 +585,67 @@ function confirmPayment(
 $chargeId = 'charge_id8';
 
 $result = $chargesController->confirmPayment($chargeId);
+```
+
+
+# Update Charge Due Date
+
+Updates the due date from a charge
+
+```php
+function updateChargeDueDate(
+    string $chargeId,
+    UpdateChargeDueDateRequest $request,
+    ?string $idempotencyKey = null
+): GetChargeResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `string` | Template, Required | Charge Id |
+| `request` | [`UpdateChargeDueDateRequest`](/doc/models/update-charge-due-date-request.md) | Body, Required | Request for updating the due date |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetChargeResponse`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```php
+$chargeId = 'charge_id8';
+$request = new Models\UpdateChargeDueDateRequest;
+
+$result = $chargesController->updateChargeDueDate($chargeId, $request);
+```
+
+
+# Retry Charge
+
+Retries a charge
+
+```php
+function retryCharge(string $chargeId, ?string $idempotencyKey = null): GetChargeResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `string` | Template, Required | Charge id |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetChargeResponse`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```php
+$chargeId = 'charge_id8';
+
+$result = $chargesController->retryCharge($chargeId);
 ```
 

--- a/doc/controllers/customers.md
+++ b/doc/controllers/customers.md
@@ -13,24 +13,24 @@ $customersController = $client->getCustomersController();
 * [Update Card](/doc/controllers/customers.md#update-card)
 * [Update Address](/doc/controllers/customers.md#update-address)
 * [Delete Access Token](/doc/controllers/customers.md#delete-access-token)
-* [Create Customer](/doc/controllers/customers.md#create-customer)
 * [Create Address](/doc/controllers/customers.md#create-address)
-* [Delete Access Tokens](/doc/controllers/customers.md#delete-access-tokens)
-* [Get Address](/doc/controllers/customers.md#get-address)
-* [Delete Address](/doc/controllers/customers.md#delete-address)
+* [Create Customer](/doc/controllers/customers.md#create-customer)
 * [Create Card](/doc/controllers/customers.md#create-card)
-* [Get Customers](/doc/controllers/customers.md#get-customers)
-* [Update Customer](/doc/controllers/customers.md#update-customer)
-* [Create Access Token](/doc/controllers/customers.md#create-access-token)
-* [Get Access Tokens](/doc/controllers/customers.md#get-access-tokens)
 * [Get Cards](/doc/controllers/customers.md#get-cards)
 * [Renew Card](/doc/controllers/customers.md#renew-card)
+* [Get Address](/doc/controllers/customers.md#get-address)
+* [Delete Address](/doc/controllers/customers.md#delete-address)
 * [Get Access Token](/doc/controllers/customers.md#get-access-token)
 * [Update Customer Metadata](/doc/controllers/customers.md#update-customer-metadata)
+* [Get Card](/doc/controllers/customers.md#get-card)
+* [Delete Access Tokens](/doc/controllers/customers.md#delete-access-tokens)
+* [Create Access Token](/doc/controllers/customers.md#create-access-token)
+* [Get Access Tokens](/doc/controllers/customers.md#get-access-tokens)
+* [Get Customers](/doc/controllers/customers.md#get-customers)
+* [Update Customer](/doc/controllers/customers.md#update-customer)
 * [Delete Card](/doc/controllers/customers.md#delete-card)
 * [Get Addresses](/doc/controllers/customers.md#get-addresses)
 * [Get Customer](/doc/controllers/customers.md#get-customer)
-* [Get Card](/doc/controllers/customers.md#get-card)
 
 
 # Update Card
@@ -188,6 +188,63 @@ $result = $customersController->deleteAccessToken($customerId, $tokenId);
 ```
 
 
+# Create Address
+
+Creates a new address for a customer
+
+```php
+function createAddress(
+    string $customerId,
+    CreateAddressRequest $request,
+    ?string $idempotencyKey = null
+): GetAddressResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer Id |
+| `request` | [`CreateAddressRequest`](/doc/models/create-address-request.md) | Body, Required | Request for creating an address |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetAddressResponse`](/doc/models/get-address-response.md)
+
+## Example Usage
+
+```php
+$customerId = 'customer_id8';
+$request_street = 'street6';
+$request_number = 'number4';
+$request_zipCode = 'zip_code0';
+$request_neighborhood = 'neighborhood2';
+$request_city = 'city6';
+$request_state = 'state2';
+$request_country = 'country0';
+$request_complement = 'complement2';
+$request_metadata = ['key0' => 'metadata3'];
+$request_line1 = 'line_10';
+$request_line2 = 'line_24';
+$request = new Models\CreateAddressRequest(
+    $request_street,
+    $request_number,
+    $request_zipCode,
+    $request_neighborhood,
+    $request_city,
+    $request_state,
+    $request_country,
+    $request_complement,
+    $request_metadata,
+    $request_line1,
+    $request_line2
+);
+
+$result = $customersController->createAddress($customerId, $request);
+```
+
+
 # Create Customer
 
 Creates a new customer
@@ -255,153 +312,6 @@ $request = new Models\CreateCustomerRequest(
 );
 
 $result = $customersController->createCustomer($request);
-```
-
-
-# Create Address
-
-Creates a new address for a customer
-
-```php
-function createAddress(
-    string $customerId,
-    CreateAddressRequest $request,
-    ?string $idempotencyKey = null
-): GetAddressResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer Id |
-| `request` | [`CreateAddressRequest`](/doc/models/create-address-request.md) | Body, Required | Request for creating an address |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetAddressResponse`](/doc/models/get-address-response.md)
-
-## Example Usage
-
-```php
-$customerId = 'customer_id8';
-$request_street = 'street6';
-$request_number = 'number4';
-$request_zipCode = 'zip_code0';
-$request_neighborhood = 'neighborhood2';
-$request_city = 'city6';
-$request_state = 'state2';
-$request_country = 'country0';
-$request_complement = 'complement2';
-$request_metadata = ['key0' => 'metadata3'];
-$request_line1 = 'line_10';
-$request_line2 = 'line_24';
-$request = new Models\CreateAddressRequest(
-    $request_street,
-    $request_number,
-    $request_zipCode,
-    $request_neighborhood,
-    $request_city,
-    $request_state,
-    $request_country,
-    $request_complement,
-    $request_metadata,
-    $request_line1,
-    $request_line2
-);
-
-$result = $customersController->createAddress($customerId, $request);
-```
-
-
-# Delete Access Tokens
-
-Delete a Customer's access tokens
-
-```php
-function deleteAccessTokens(string $customerId): ListAccessTokensResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer Id |
-
-## Response Type
-
-[`ListAccessTokensResponse`](/doc/models/list-access-tokens-response.md)
-
-## Example Usage
-
-```php
-$customerId = 'customer_id8';
-
-$result = $customersController->deleteAccessTokens($customerId);
-```
-
-
-# Get Address
-
-Get a customer's address
-
-```php
-function getAddress(string $customerId, string $addressId): GetAddressResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer id |
-| `addressId` | `string` | Template, Required | Address Id |
-
-## Response Type
-
-[`GetAddressResponse`](/doc/models/get-address-response.md)
-
-## Example Usage
-
-```php
-$customerId = 'customer_id8';
-$addressId = 'address_id0';
-
-$result = $customersController->getAddress($customerId, $addressId);
-```
-
-
-# Delete Address
-
-Delete a Customer's address
-
-```php
-function deleteAddress(
-    string $customerId,
-    string $addressId,
-    ?string $idempotencyKey = null
-): GetAddressResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer Id |
-| `addressId` | `string` | Template, Required | Address Id |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetAddressResponse`](/doc/models/get-address-response.md)
-
-## Example Usage
-
-```php
-$customerId = 'customer_id8';
-$addressId = 'address_id0';
-
-$result = $customersController->deleteAddress($customerId, $addressId);
 ```
 
 
@@ -492,6 +402,313 @@ $result = $customersController->createCard($customerId, $request);
 ```
 
 
+# Get Cards
+
+Get all cards from a customer
+
+```php
+function getCards(string $customerId, ?int $page = null, ?int $size = null): ListCardsResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer Id |
+| `page` | `?int` | Query, Optional | Page number |
+| `size` | `?int` | Query, Optional | Page size |
+
+## Response Type
+
+[`ListCardsResponse`](/doc/models/list-cards-response.md)
+
+## Example Usage
+
+```php
+$customerId = 'customer_id8';
+
+$result = $customersController->getCards($customerId);
+```
+
+
+# Renew Card
+
+Renew a card
+
+```php
+function renewCard(string $customerId, string $cardId, ?string $idempotencyKey = null): GetCardResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer id |
+| `cardId` | `string` | Template, Required | Card Id |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetCardResponse`](/doc/models/get-card-response.md)
+
+## Example Usage
+
+```php
+$customerId = 'customer_id8';
+$cardId = 'card_id4';
+
+$result = $customersController->renewCard($customerId, $cardId);
+```
+
+
+# Get Address
+
+Get a customer's address
+
+```php
+function getAddress(string $customerId, string $addressId): GetAddressResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer id |
+| `addressId` | `string` | Template, Required | Address Id |
+
+## Response Type
+
+[`GetAddressResponse`](/doc/models/get-address-response.md)
+
+## Example Usage
+
+```php
+$customerId = 'customer_id8';
+$addressId = 'address_id0';
+
+$result = $customersController->getAddress($customerId, $addressId);
+```
+
+
+# Delete Address
+
+Delete a Customer's address
+
+```php
+function deleteAddress(
+    string $customerId,
+    string $addressId,
+    ?string $idempotencyKey = null
+): GetAddressResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer Id |
+| `addressId` | `string` | Template, Required | Address Id |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetAddressResponse`](/doc/models/get-address-response.md)
+
+## Example Usage
+
+```php
+$customerId = 'customer_id8';
+$addressId = 'address_id0';
+
+$result = $customersController->deleteAddress($customerId, $addressId);
+```
+
+
+# Get Access Token
+
+Get a Customer's access token
+
+```php
+function getAccessToken(string $customerId, string $tokenId): GetAccessTokenResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer Id |
+| `tokenId` | `string` | Template, Required | Token Id |
+
+## Response Type
+
+[`GetAccessTokenResponse`](/doc/models/get-access-token-response.md)
+
+## Example Usage
+
+```php
+$customerId = 'customer_id8';
+$tokenId = 'token_id6';
+
+$result = $customersController->getAccessToken($customerId, $tokenId);
+```
+
+
+# Update Customer Metadata
+
+Updates the metadata a customer
+
+```php
+function updateCustomerMetadata(
+    string $customerId,
+    UpdateMetadataRequest $request,
+    ?string $idempotencyKey = null
+): GetCustomerResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | The customer id |
+| `request` | [`UpdateMetadataRequest`](/doc/models/update-metadata-request.md) | Body, Required | Request for updating the customer metadata |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetCustomerResponse`](/doc/models/get-customer-response.md)
+
+## Example Usage
+
+```php
+$customerId = 'customer_id8';
+$request_metadata = ['key0' => 'metadata3'];
+$request = new Models\UpdateMetadataRequest(
+    $request_metadata
+);
+
+$result = $customersController->updateCustomerMetadata($customerId, $request);
+```
+
+
+# Get Card
+
+Get a customer's card
+
+```php
+function getCard(string $customerId, string $cardId): GetCardResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer id |
+| `cardId` | `string` | Template, Required | Card id |
+
+## Response Type
+
+[`GetCardResponse`](/doc/models/get-card-response.md)
+
+## Example Usage
+
+```php
+$customerId = 'customer_id8';
+$cardId = 'card_id4';
+
+$result = $customersController->getCard($customerId, $cardId);
+```
+
+
+# Delete Access Tokens
+
+Delete a Customer's access tokens
+
+```php
+function deleteAccessTokens(string $customerId): ListAccessTokensResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer Id |
+
+## Response Type
+
+[`ListAccessTokensResponse`](/doc/models/list-access-tokens-response.md)
+
+## Example Usage
+
+```php
+$customerId = 'customer_id8';
+
+$result = $customersController->deleteAccessTokens($customerId);
+```
+
+
+# Create Access Token
+
+Creates a access token for a customer
+
+```php
+function createAccessToken(
+    string $customerId,
+    CreateAccessTokenRequest $request,
+    ?string $idempotencyKey = null
+): GetAccessTokenResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer Id |
+| `request` | [`CreateAccessTokenRequest`](/doc/models/create-access-token-request.md) | Body, Required | Request for creating a access token |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetAccessTokenResponse`](/doc/models/get-access-token-response.md)
+
+## Example Usage
+
+```php
+$customerId = 'customer_id8';
+$request = new Models\CreateAccessTokenRequest;
+
+$result = $customersController->createAccessToken($customerId, $request);
+```
+
+
+# Get Access Tokens
+
+Get all access tokens from a customer
+
+```php
+function getAccessTokens(string $customerId, ?int $page = null, ?int $size = null): ListAccessTokensResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer Id |
+| `page` | `?int` | Query, Optional | Page number |
+| `size` | `?int` | Query, Optional | Page size |
+
+## Response Type
+
+[`ListAccessTokensResponse`](/doc/models/list-access-tokens-response.md)
+
+## Example Usage
+
+```php
+$customerId = 'customer_id8';
+
+$result = $customersController->getAccessTokens($customerId);
+```
+
+
 # Get Customers
 
 Get all Customers
@@ -563,194 +780,6 @@ $customerId = 'customer_id8';
 $request = new Models\UpdateCustomerRequest;
 
 $result = $customersController->updateCustomer($customerId, $request);
-```
-
-
-# Create Access Token
-
-Creates a access token for a customer
-
-```php
-function createAccessToken(
-    string $customerId,
-    CreateAccessTokenRequest $request,
-    ?string $idempotencyKey = null
-): GetAccessTokenResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer Id |
-| `request` | [`CreateAccessTokenRequest`](/doc/models/create-access-token-request.md) | Body, Required | Request for creating a access token |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetAccessTokenResponse`](/doc/models/get-access-token-response.md)
-
-## Example Usage
-
-```php
-$customerId = 'customer_id8';
-$request = new Models\CreateAccessTokenRequest;
-
-$result = $customersController->createAccessToken($customerId, $request);
-```
-
-
-# Get Access Tokens
-
-Get all access tokens from a customer
-
-```php
-function getAccessTokens(string $customerId, ?int $page = null, ?int $size = null): ListAccessTokensResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer Id |
-| `page` | `?int` | Query, Optional | Page number |
-| `size` | `?int` | Query, Optional | Page size |
-
-## Response Type
-
-[`ListAccessTokensResponse`](/doc/models/list-access-tokens-response.md)
-
-## Example Usage
-
-```php
-$customerId = 'customer_id8';
-
-$result = $customersController->getAccessTokens($customerId);
-```
-
-
-# Get Cards
-
-Get all cards from a customer
-
-```php
-function getCards(string $customerId, ?int $page = null, ?int $size = null): ListCardsResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer Id |
-| `page` | `?int` | Query, Optional | Page number |
-| `size` | `?int` | Query, Optional | Page size |
-
-## Response Type
-
-[`ListCardsResponse`](/doc/models/list-cards-response.md)
-
-## Example Usage
-
-```php
-$customerId = 'customer_id8';
-
-$result = $customersController->getCards($customerId);
-```
-
-
-# Renew Card
-
-Renew a card
-
-```php
-function renewCard(string $customerId, string $cardId, ?string $idempotencyKey = null): GetCardResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer id |
-| `cardId` | `string` | Template, Required | Card Id |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetCardResponse`](/doc/models/get-card-response.md)
-
-## Example Usage
-
-```php
-$customerId = 'customer_id8';
-$cardId = 'card_id4';
-
-$result = $customersController->renewCard($customerId, $cardId);
-```
-
-
-# Get Access Token
-
-Get a Customer's access token
-
-```php
-function getAccessToken(string $customerId, string $tokenId): GetAccessTokenResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer Id |
-| `tokenId` | `string` | Template, Required | Token Id |
-
-## Response Type
-
-[`GetAccessTokenResponse`](/doc/models/get-access-token-response.md)
-
-## Example Usage
-
-```php
-$customerId = 'customer_id8';
-$tokenId = 'token_id6';
-
-$result = $customersController->getAccessToken($customerId, $tokenId);
-```
-
-
-# Update Customer Metadata
-
-Updates the metadata a customer
-
-```php
-function updateCustomerMetadata(
-    string $customerId,
-    UpdateMetadataRequest $request,
-    ?string $idempotencyKey = null
-): GetCustomerResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | The customer id |
-| `request` | [`UpdateMetadataRequest`](/doc/models/update-metadata-request.md) | Body, Required | Request for updating the customer metadata |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetCustomerResponse`](/doc/models/get-customer-response.md)
-
-## Example Usage
-
-```php
-$customerId = 'customer_id8';
-$request_metadata = ['key0' => 'metadata3'];
-$request = new Models\UpdateMetadataRequest(
-    $request_metadata
-);
-
-$result = $customersController->updateCustomerMetadata($customerId, $request);
 ```
 
 
@@ -837,34 +866,5 @@ function getCustomer(string $customerId): GetCustomerResponse
 $customerId = 'customer_id8';
 
 $result = $customersController->getCustomer($customerId);
-```
-
-
-# Get Card
-
-Get a customer's card
-
-```php
-function getCard(string $customerId, string $cardId): GetCardResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer id |
-| `cardId` | `string` | Template, Required | Card id |
-
-## Response Type
-
-[`GetCardResponse`](/doc/models/get-card-response.md)
-
-## Example Usage
-
-```php
-$customerId = 'customer_id8';
-$cardId = 'card_id4';
-
-$result = $customersController->getCard($customerId, $cardId);
 ```
 

--- a/doc/controllers/invoices.md
+++ b/doc/controllers/invoices.md
@@ -10,103 +10,13 @@ $invoicesController = $client->getInvoicesController();
 
 ## Methods
 
-* [Update Invoice Metadata](/doc/controllers/invoices.md#update-invoice-metadata)
-* [Get Partial Invoice](/doc/controllers/invoices.md#get-partial-invoice)
-* [Cancel Invoice](/doc/controllers/invoices.md#cancel-invoice)
 * [Create Invoice](/doc/controllers/invoices.md#create-invoice)
 * [Get Invoices](/doc/controllers/invoices.md#get-invoices)
-* [Get Invoice](/doc/controllers/invoices.md#get-invoice)
+* [Cancel Invoice](/doc/controllers/invoices.md#cancel-invoice)
+* [Update Invoice Metadata](/doc/controllers/invoices.md#update-invoice-metadata)
+* [Get Partial Invoice](/doc/controllers/invoices.md#get-partial-invoice)
 * [Update Invoice Status](/doc/controllers/invoices.md#update-invoice-status)
-
-
-# Update Invoice Metadata
-
-Updates the metadata from an invoice
-
-```php
-function updateInvoiceMetadata(
-    string $invoiceId,
-    UpdateMetadataRequest $request,
-    ?string $idempotencyKey = null
-): GetInvoiceResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `invoiceId` | `string` | Template, Required | The invoice id |
-| `request` | [`UpdateMetadataRequest`](/doc/models/update-metadata-request.md) | Body, Required | Request for updating the invoice metadata |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetInvoiceResponse`](/doc/models/get-invoice-response.md)
-
-## Example Usage
-
-```php
-$invoiceId = 'invoice_id0';
-$request_metadata = ['key0' => 'metadata3'];
-$request = new Models\UpdateMetadataRequest(
-    $request_metadata
-);
-
-$result = $invoicesController->updateInvoiceMetadata($invoiceId, $request);
-```
-
-
-# Get Partial Invoice
-
-```php
-function getPartialInvoice(string $subscriptionId): GetInvoiceResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription Id |
-
-## Response Type
-
-[`GetInvoiceResponse`](/doc/models/get-invoice-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-
-$result = $invoicesController->getPartialInvoice($subscriptionId);
-```
-
-
-# Cancel Invoice
-
-Cancels an invoice
-
-```php
-function cancelInvoice(string $invoiceId, ?string $idempotencyKey = null): GetInvoiceResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `invoiceId` | `string` | Template, Required | Invoice id |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetInvoiceResponse`](/doc/models/get-invoice-response.md)
-
-## Example Usage
-
-```php
-$invoiceId = 'invoice_id0';
-
-$result = $invoicesController->cancelInvoice($invoiceId);
-```
+* [Get Invoice](/doc/controllers/invoices.md#get-invoice)
 
 
 # Create Invoice
@@ -192,19 +102,20 @@ $result = $invoicesController->getInvoices();
 ```
 
 
-# Get Invoice
+# Cancel Invoice
 
-Gets an invoice
+Cancels an invoice
 
 ```php
-function getInvoice(string $invoiceId): GetInvoiceResponse
+function cancelInvoice(string $invoiceId, ?string $idempotencyKey = null): GetInvoiceResponse
 ```
 
 ## Parameters
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `invoiceId` | `string` | Template, Required | Invoice Id |
+| `invoiceId` | `string` | Template, Required | Invoice id |
+| `idempotencyKey` | `?string` | Header, Optional | - |
 
 ## Response Type
 
@@ -215,7 +126,69 @@ function getInvoice(string $invoiceId): GetInvoiceResponse
 ```php
 $invoiceId = 'invoice_id0';
 
-$result = $invoicesController->getInvoice($invoiceId);
+$result = $invoicesController->cancelInvoice($invoiceId);
+```
+
+
+# Update Invoice Metadata
+
+Updates the metadata from an invoice
+
+```php
+function updateInvoiceMetadata(
+    string $invoiceId,
+    UpdateMetadataRequest $request,
+    ?string $idempotencyKey = null
+): GetInvoiceResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `invoiceId` | `string` | Template, Required | The invoice id |
+| `request` | [`UpdateMetadataRequest`](/doc/models/update-metadata-request.md) | Body, Required | Request for updating the invoice metadata |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetInvoiceResponse`](/doc/models/get-invoice-response.md)
+
+## Example Usage
+
+```php
+$invoiceId = 'invoice_id0';
+$request_metadata = ['key0' => 'metadata3'];
+$request = new Models\UpdateMetadataRequest(
+    $request_metadata
+);
+
+$result = $invoicesController->updateInvoiceMetadata($invoiceId, $request);
+```
+
+
+# Get Partial Invoice
+
+```php
+function getPartialInvoice(string $subscriptionId): GetInvoiceResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription Id |
+
+## Response Type
+
+[`GetInvoiceResponse`](/doc/models/get-invoice-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+
+$result = $invoicesController->getPartialInvoice($subscriptionId);
 ```
 
 
@@ -253,5 +226,32 @@ $request = new Models\UpdateInvoiceStatusRequest(
 );
 
 $result = $invoicesController->updateInvoiceStatus($invoiceId, $request);
+```
+
+
+# Get Invoice
+
+Gets an invoice
+
+```php
+function getInvoice(string $invoiceId): GetInvoiceResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `invoiceId` | `string` | Template, Required | Invoice Id |
+
+## Response Type
+
+[`GetInvoiceResponse`](/doc/models/get-invoice-response.md)
+
+## Example Usage
+
+```php
+$invoiceId = 'invoice_id0';
+
+$result = $invoicesController->getInvoice($invoiceId);
 ```
 

--- a/doc/controllers/orders.md
+++ b/doc/controllers/orders.md
@@ -11,15 +11,15 @@ $ordersController = $client->getOrdersController();
 ## Methods
 
 * [Get Orders](/doc/controllers/orders.md#get-orders)
-* [Update Order Item](/doc/controllers/orders.md#update-order-item)
-* [Delete All Order Items](/doc/controllers/orders.md#delete-all-order-items)
-* [Delete Order Item](/doc/controllers/orders.md#delete-order-item)
+* [Get Order Item](/doc/controllers/orders.md#get-order-item)
+* [Get Order](/doc/controllers/orders.md#get-order)
 * [Close Order](/doc/controllers/orders.md#close-order)
 * [Create Order](/doc/controllers/orders.md#create-order)
-* [Create Order Item](/doc/controllers/orders.md#create-order-item)
-* [Get Order Item](/doc/controllers/orders.md#get-order-item)
+* [Update Order Item](/doc/controllers/orders.md#update-order-item)
+* [Delete All Order Items](/doc/controllers/orders.md#delete-all-order-items)
 * [Update Order Metadata](/doc/controllers/orders.md#update-order-metadata)
-* [Get Order](/doc/controllers/orders.md#get-order)
+* [Delete Order Item](/doc/controllers/orders.md#delete-order-item)
+* [Create Order Item](/doc/controllers/orders.md#create-order-item)
 
 
 # Get Orders
@@ -61,15 +61,10 @@ $result = $ordersController->getOrders();
 ```
 
 
-# Update Order Item
+# Get Order Item
 
 ```php
-function updateOrderItem(
-    string $orderId,
-    string $itemId,
-    UpdateOrderItemRequest $request,
-    ?string $idempotencyKey = null
-): GetOrderItemResponse
+function getOrderItem(string $orderId, string $itemId): GetOrderItemResponse
 ```
 
 ## Parameters
@@ -78,8 +73,6 @@ function updateOrderItem(
 |  --- | --- | --- | --- |
 | `orderId` | `string` | Template, Required | Order Id |
 | `itemId` | `string` | Template, Required | Item Id |
-| `request` | [`UpdateOrderItemRequest`](/doc/models/update-order-item-request.md) | Body, Required | Item Model |
-| `idempotencyKey` | `?string` | Header, Optional | - |
 
 ## Response Type
 
@@ -90,33 +83,24 @@ function updateOrderItem(
 ```php
 $orderId = 'orderId2';
 $itemId = 'itemId8';
-$request_amount = 242;
-$request_description = 'description6';
-$request_quantity = 100;
-$request_category = 'category4';
-$request = new Models\UpdateOrderItemRequest(
-    $request_amount,
-    $request_description,
-    $request_quantity,
-    $request_category
-);
 
-$result = $ordersController->updateOrderItem($orderId, $itemId, $request);
+$result = $ordersController->getOrderItem($orderId, $itemId);
 ```
 
 
-# Delete All Order Items
+# Get Order
+
+Gets an order
 
 ```php
-function deleteAllOrderItems(string $orderId, ?string $idempotencyKey = null): GetOrderResponse
+function getOrder(string $orderId): GetOrderResponse
 ```
 
 ## Parameters
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `orderId` | `string` | Template, Required | Order Id |
-| `idempotencyKey` | `?string` | Header, Optional | - |
+| `orderId` | `string` | Template, Required | Order id |
 
 ## Response Type
 
@@ -125,37 +109,9 @@ function deleteAllOrderItems(string $orderId, ?string $idempotencyKey = null): G
 ## Example Usage
 
 ```php
-$orderId = 'orderId2';
+$orderId = 'order_id6';
 
-$result = $ordersController->deleteAllOrderItems($orderId);
-```
-
-
-# Delete Order Item
-
-```php
-function deleteOrderItem(string $orderId, string $itemId, ?string $idempotencyKey = null): GetOrderItemResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `orderId` | `string` | Template, Required | Order Id |
-| `itemId` | `string` | Template, Required | Item Id |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetOrderItemResponse`](/doc/models/get-order-item-response.md)
-
-## Example Usage
-
-```php
-$orderId = 'orderId2';
-$itemId = 'itemId8';
-
-$result = $ordersController->deleteOrderItem($orderId, $itemId);
+$result = $ordersController->getOrder($orderId);
 ```
 
 
@@ -328,12 +284,13 @@ $result = $ordersController->createOrder($body);
 ```
 
 
-# Create Order Item
+# Update Order Item
 
 ```php
-function createOrderItem(
+function updateOrderItem(
     string $orderId,
-    CreateOrderItemRequest $request,
+    string $itemId,
+    UpdateOrderItemRequest $request,
     ?string $idempotencyKey = null
 ): GetOrderItemResponse
 ```
@@ -343,7 +300,8 @@ function createOrderItem(
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
 | `orderId` | `string` | Template, Required | Order Id |
-| `request` | [`CreateOrderItemRequest`](/doc/models/create-order-item-request.md) | Body, Required | Order Item Model |
+| `itemId` | `string` | Template, Required | Item Id |
+| `request` | [`UpdateOrderItemRequest`](/doc/models/update-order-item-request.md) | Body, Required | Item Model |
 | `idempotencyKey` | `?string` | Header, Optional | - |
 
 ## Response Type
@@ -354,25 +312,26 @@ function createOrderItem(
 
 ```php
 $orderId = 'orderId2';
+$itemId = 'itemId8';
 $request_amount = 242;
 $request_description = 'description6';
 $request_quantity = 100;
 $request_category = 'category4';
-$request = new Models\CreateOrderItemRequest(
+$request = new Models\UpdateOrderItemRequest(
     $request_amount,
     $request_description,
     $request_quantity,
     $request_category
 );
 
-$result = $ordersController->createOrderItem($orderId, $request);
+$result = $ordersController->updateOrderItem($orderId, $itemId, $request);
 ```
 
 
-# Get Order Item
+# Delete All Order Items
 
 ```php
-function getOrderItem(string $orderId, string $itemId): GetOrderItemResponse
+function deleteAllOrderItems(string $orderId, ?string $idempotencyKey = null): GetOrderResponse
 ```
 
 ## Parameters
@@ -380,19 +339,18 @@ function getOrderItem(string $orderId, string $itemId): GetOrderItemResponse
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
 | `orderId` | `string` | Template, Required | Order Id |
-| `itemId` | `string` | Template, Required | Item Id |
+| `idempotencyKey` | `?string` | Header, Optional | - |
 
 ## Response Type
 
-[`GetOrderItemResponse`](/doc/models/get-order-item-response.md)
+[`GetOrderResponse`](/doc/models/get-order-response.md)
 
 ## Example Usage
 
 ```php
 $orderId = 'orderId2';
-$itemId = 'itemId8';
 
-$result = $ordersController->getOrderItem($orderId, $itemId);
+$result = $ordersController->deleteAllOrderItems($orderId);
 ```
 
 
@@ -433,29 +391,71 @@ $result = $ordersController->updateOrderMetadata($orderId, $request);
 ```
 
 
-# Get Order
-
-Gets an order
+# Delete Order Item
 
 ```php
-function getOrder(string $orderId): GetOrderResponse
+function deleteOrderItem(string $orderId, string $itemId, ?string $idempotencyKey = null): GetOrderItemResponse
 ```
 
 ## Parameters
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `orderId` | `string` | Template, Required | Order id |
+| `orderId` | `string` | Template, Required | Order Id |
+| `itemId` | `string` | Template, Required | Item Id |
+| `idempotencyKey` | `?string` | Header, Optional | - |
 
 ## Response Type
 
-[`GetOrderResponse`](/doc/models/get-order-response.md)
+[`GetOrderItemResponse`](/doc/models/get-order-item-response.md)
 
 ## Example Usage
 
 ```php
-$orderId = 'order_id6';
+$orderId = 'orderId2';
+$itemId = 'itemId8';
 
-$result = $ordersController->getOrder($orderId);
+$result = $ordersController->deleteOrderItem($orderId, $itemId);
+```
+
+
+# Create Order Item
+
+```php
+function createOrderItem(
+    string $orderId,
+    CreateOrderItemRequest $request,
+    ?string $idempotencyKey = null
+): GetOrderItemResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `orderId` | `string` | Template, Required | Order Id |
+| `request` | [`CreateOrderItemRequest`](/doc/models/create-order-item-request.md) | Body, Required | Order Item Model |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetOrderItemResponse`](/doc/models/get-order-item-response.md)
+
+## Example Usage
+
+```php
+$orderId = 'orderId2';
+$request_amount = 242;
+$request_description = 'description6';
+$request_quantity = 100;
+$request_category = 'category4';
+$request = new Models\CreateOrderItemRequest(
+    $request_amount,
+    $request_description,
+    $request_quantity,
+    $request_category
+);
+
+$result = $ordersController->createOrderItem($orderId, $request);
 ```
 

--- a/doc/controllers/plans.md
+++ b/doc/controllers/plans.md
@@ -11,15 +11,15 @@ $plansController = $client->getPlansController();
 ## Methods
 
 * [Get Plan](/doc/controllers/plans.md#get-plan)
-* [Delete Plan](/doc/controllers/plans.md#delete-plan)
+* [Update Plan](/doc/controllers/plans.md#update-plan)
 * [Update Plan Metadata](/doc/controllers/plans.md#update-plan-metadata)
-* [Update Plan Item](/doc/controllers/plans.md#update-plan-item)
-* [Create Plan Item](/doc/controllers/plans.md#create-plan-item)
-* [Get Plan Item](/doc/controllers/plans.md#get-plan-item)
-* [Create Plan](/doc/controllers/plans.md#create-plan)
 * [Delete Plan Item](/doc/controllers/plans.md#delete-plan-item)
 * [Get Plans](/doc/controllers/plans.md#get-plans)
-* [Update Plan](/doc/controllers/plans.md#update-plan)
+* [Get Plan Item](/doc/controllers/plans.md#get-plan-item)
+* [Delete Plan](/doc/controllers/plans.md#delete-plan)
+* [Update Plan Item](/doc/controllers/plans.md#update-plan-item)
+* [Create Plan Item](/doc/controllers/plans.md#create-plan-item)
+* [Create Plan](/doc/controllers/plans.md#create-plan)
 
 
 # Get Plan
@@ -49,12 +49,12 @@ $result = $plansController->getPlan($planId);
 ```
 
 
-# Delete Plan
+# Update Plan
 
-Deletes a plan
+Updates a plan
 
 ```php
-function deletePlan(string $planId, ?string $idempotencyKey = null): GetPlanResponse
+function updatePlan(string $planId, UpdatePlanRequest $request, ?string $idempotencyKey = null): GetPlanResponse
 ```
 
 ## Parameters
@@ -62,6 +62,7 @@ function deletePlan(string $planId, ?string $idempotencyKey = null): GetPlanResp
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
 | `planId` | `string` | Template, Required | Plan id |
+| `request` | [`UpdatePlanRequest`](/doc/models/update-plan-request.md) | Body, Required | Request for updating a plan |
 | `idempotencyKey` | `?string` | Header, Optional | - |
 
 ## Response Type
@@ -72,8 +73,36 @@ function deletePlan(string $planId, ?string $idempotencyKey = null): GetPlanResp
 
 ```php
 $planId = 'plan_id8';
+$request_name = 'name6';
+$request_description = 'description6';
+$request_installments = [151, 152];
+$request_statementDescriptor = 'statement_descriptor6';
+$request_currency = 'currency6';
+$request_interval = 'interval4';
+$request_intervalCount = 114;
+$request_paymentMethods = ['payment_methods1', 'payment_methods0', 'payment_methods9'];
+$request_billingType = 'billing_type0';
+$request_status = 'status8';
+$request_shippable = false;
+$request_billingDays = [115];
+$request_metadata = ['key0' => 'metadata3'];
+$request = new Models\UpdatePlanRequest(
+    $request_name,
+    $request_description,
+    $request_installments,
+    $request_statementDescriptor,
+    $request_currency,
+    $request_interval,
+    $request_intervalCount,
+    $request_paymentMethods,
+    $request_billingType,
+    $request_status,
+    $request_shippable,
+    $request_billingDays,
+    $request_metadata
+);
 
-$result = $plansController->deletePlan($planId);
+$result = $plansController->updatePlan($planId, $request);
 ```
 
 
@@ -111,6 +140,132 @@ $request = new Models\UpdateMetadataRequest(
 );
 
 $result = $plansController->updatePlanMetadata($planId, $request);
+```
+
+
+# Delete Plan Item
+
+Removes an item from a plan
+
+```php
+function deletePlanItem(string $planId, string $planItemId, ?string $idempotencyKey = null): GetPlanItemResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `planId` | `string` | Template, Required | Plan id |
+| `planItemId` | `string` | Template, Required | Plan item id |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetPlanItemResponse`](/doc/models/get-plan-item-response.md)
+
+## Example Usage
+
+```php
+$planId = 'plan_id8';
+$planItemId = 'plan_item_id0';
+
+$result = $plansController->deletePlanItem($planId, $planItemId);
+```
+
+
+# Get Plans
+
+Gets all plans
+
+```php
+function getPlans(
+    ?int $page = null,
+    ?int $size = null,
+    ?string $name = null,
+    ?string $status = null,
+    ?string $billingType = null,
+    ?\DateTime $createdSince = null,
+    ?\DateTime $createdUntil = null
+): ListPlansResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `page` | `?int` | Query, Optional | Page number |
+| `size` | `?int` | Query, Optional | Page size |
+| `name` | `?string` | Query, Optional | Filter for Plan's name |
+| `status` | `?string` | Query, Optional | Filter for Plan's status |
+| `billingType` | `?string` | Query, Optional | Filter for plan's billing type |
+| `createdSince` | `?\DateTime` | Query, Optional | Filter for plan's creation date start range |
+| `createdUntil` | `?\DateTime` | Query, Optional | Filter for plan's creation date end range |
+
+## Response Type
+
+[`ListPlansResponse`](/doc/models/list-plans-response.md)
+
+## Example Usage
+
+```php
+$result = $plansController->getPlans();
+```
+
+
+# Get Plan Item
+
+Gets a plan item
+
+```php
+function getPlanItem(string $planId, string $planItemId): GetPlanItemResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `planId` | `string` | Template, Required | Plan id |
+| `planItemId` | `string` | Template, Required | Plan item id |
+
+## Response Type
+
+[`GetPlanItemResponse`](/doc/models/get-plan-item-response.md)
+
+## Example Usage
+
+```php
+$planId = 'plan_id8';
+$planItemId = 'plan_item_id0';
+
+$result = $plansController->getPlanItem($planId, $planItemId);
+```
+
+
+# Delete Plan
+
+Deletes a plan
+
+```php
+function deletePlan(string $planId, ?string $idempotencyKey = null): GetPlanResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `planId` | `string` | Template, Required | Plan id |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetPlanResponse`](/doc/models/get-plan-response.md)
+
+## Example Usage
+
+```php
+$planId = 'plan_id8';
+
+$result = $plansController->deletePlan($planId);
 ```
 
 
@@ -233,35 +388,6 @@ $request = new Models\CreatePlanItemRequest(
 );
 
 $result = $plansController->createPlanItem($planId, $request);
-```
-
-
-# Get Plan Item
-
-Gets a plan item
-
-```php
-function getPlanItem(string $planId, string $planItemId): GetPlanItemResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `planId` | `string` | Template, Required | Plan id |
-| `planItemId` | `string` | Template, Required | Plan item id |
-
-## Response Type
-
-[`GetPlanItemResponse`](/doc/models/get-plan-item-response.md)
-
-## Example Usage
-
-```php
-$planId = 'plan_id8';
-$planItemId = 'plan_item_id0';
-
-$result = $plansController->getPlanItem($planId, $planItemId);
 ```
 
 
@@ -433,131 +559,5 @@ $body = new Models\CreatePlanRequest(
 );
 
 $result = $plansController->createPlan($body);
-```
-
-
-# Delete Plan Item
-
-Removes an item from a plan
-
-```php
-function deletePlanItem(string $planId, string $planItemId, ?string $idempotencyKey = null): GetPlanItemResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `planId` | `string` | Template, Required | Plan id |
-| `planItemId` | `string` | Template, Required | Plan item id |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetPlanItemResponse`](/doc/models/get-plan-item-response.md)
-
-## Example Usage
-
-```php
-$planId = 'plan_id8';
-$planItemId = 'plan_item_id0';
-
-$result = $plansController->deletePlanItem($planId, $planItemId);
-```
-
-
-# Get Plans
-
-Gets all plans
-
-```php
-function getPlans(
-    ?int $page = null,
-    ?int $size = null,
-    ?string $name = null,
-    ?string $status = null,
-    ?string $billingType = null,
-    ?\DateTime $createdSince = null,
-    ?\DateTime $createdUntil = null
-): ListPlansResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `page` | `?int` | Query, Optional | Page number |
-| `size` | `?int` | Query, Optional | Page size |
-| `name` | `?string` | Query, Optional | Filter for Plan's name |
-| `status` | `?string` | Query, Optional | Filter for Plan's status |
-| `billingType` | `?string` | Query, Optional | Filter for plan's billing type |
-| `createdSince` | `?\DateTime` | Query, Optional | Filter for plan's creation date start range |
-| `createdUntil` | `?\DateTime` | Query, Optional | Filter for plan's creation date end range |
-
-## Response Type
-
-[`ListPlansResponse`](/doc/models/list-plans-response.md)
-
-## Example Usage
-
-```php
-$result = $plansController->getPlans();
-```
-
-
-# Update Plan
-
-Updates a plan
-
-```php
-function updatePlan(string $planId, UpdatePlanRequest $request, ?string $idempotencyKey = null): GetPlanResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `planId` | `string` | Template, Required | Plan id |
-| `request` | [`UpdatePlanRequest`](/doc/models/update-plan-request.md) | Body, Required | Request for updating a plan |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetPlanResponse`](/doc/models/get-plan-response.md)
-
-## Example Usage
-
-```php
-$planId = 'plan_id8';
-$request_name = 'name6';
-$request_description = 'description6';
-$request_installments = [151, 152];
-$request_statementDescriptor = 'statement_descriptor6';
-$request_currency = 'currency6';
-$request_interval = 'interval4';
-$request_intervalCount = 114;
-$request_paymentMethods = ['payment_methods1', 'payment_methods0', 'payment_methods9'];
-$request_billingType = 'billing_type0';
-$request_status = 'status8';
-$request_shippable = false;
-$request_billingDays = [115];
-$request_metadata = ['key0' => 'metadata3'];
-$request = new Models\UpdatePlanRequest(
-    $request_name,
-    $request_description,
-    $request_installments,
-    $request_statementDescriptor,
-    $request_currency,
-    $request_interval,
-    $request_intervalCount,
-    $request_paymentMethods,
-    $request_billingType,
-    $request_status,
-    $request_shippable,
-    $request_billingDays,
-    $request_metadata
-);
-
-$result = $plansController->updatePlan($planId, $request);
 ```
 

--- a/doc/controllers/recipients.md
+++ b/doc/controllers/recipients.md
@@ -14,21 +14,21 @@ $recipientsController = $client->getRecipientsController();
 * [Create Anticipation](/doc/controllers/recipients.md#create-anticipation)
 * [Get Anticipation Limits](/doc/controllers/recipients.md#get-anticipation-limits)
 * [Get Recipients](/doc/controllers/recipients.md#get-recipients)
-* [Get Withdraw by Id](/doc/controllers/recipients.md#get-withdraw-by-id)
-* [Update Recipient Default Bank Account](/doc/controllers/recipients.md#update-recipient-default-bank-account)
 * [Update Recipient Metadata](/doc/controllers/recipients.md#update-recipient-metadata)
-* [Get Transfers](/doc/controllers/recipients.md#get-transfers)
 * [Get Transfer](/doc/controllers/recipients.md#get-transfer)
-* [Create Withdraw](/doc/controllers/recipients.md#create-withdraw)
-* [Update Automatic Anticipation Settings](/doc/controllers/recipients.md#update-automatic-anticipation-settings)
 * [Get Anticipation](/doc/controllers/recipients.md#get-anticipation)
 * [Update Recipient Transfer Settings](/doc/controllers/recipients.md#update-recipient-transfer-settings)
 * [Get Anticipations](/doc/controllers/recipients.md#get-anticipations)
-* [Get Recipient](/doc/controllers/recipients.md#get-recipient)
+* [Update Recipient Default Bank Account](/doc/controllers/recipients.md#update-recipient-default-bank-account)
+* [Create Withdraw](/doc/controllers/recipients.md#create-withdraw)
 * [Get Balance](/doc/controllers/recipients.md#get-balance)
-* [Get Withdrawals](/doc/controllers/recipients.md#get-withdrawals)
 * [Create Transfer](/doc/controllers/recipients.md#create-transfer)
 * [Create Recipient](/doc/controllers/recipients.md#create-recipient)
+* [Update Automatic Anticipation Settings](/doc/controllers/recipients.md#update-automatic-anticipation-settings)
+* [Get Recipient](/doc/controllers/recipients.md#get-recipient)
+* [Get Withdrawals](/doc/controllers/recipients.md#get-withdrawals)
+* [Get Withdraw by Id](/doc/controllers/recipients.md#get-withdraw-by-id)
+* [Get Transfers](/doc/controllers/recipients.md#get-transfers)
 * [Get Recipient by Code](/doc/controllers/recipients.md#get-recipient-by-code)
 * [Get Default Recipient](/doc/controllers/recipients.md#get-default-recipient)
 
@@ -182,95 +182,6 @@ $result = $recipientsController->getRecipients();
 ```
 
 
-# Get Withdraw by Id
-
-```php
-function getWithdrawById(string $recipientId, string $withdrawalId): GetWithdrawResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | - |
-| `withdrawalId` | `string` | Template, Required | - |
-
-## Response Type
-
-[`GetWithdrawResponse`](/doc/models/get-withdraw-response.md)
-
-## Example Usage
-
-```php
-$recipientId = 'recipient_id0';
-$withdrawalId = 'withdrawal_id2';
-
-$result = $recipientsController->getWithdrawById($recipientId, $withdrawalId);
-```
-
-
-# Update Recipient Default Bank Account
-
-Updates the default bank account from a recipient
-
-```php
-function updateRecipientDefaultBankAccount(
-    string $recipientId,
-    UpdateRecipientBankAccountRequest $request,
-    ?string $idempotencyKey = null
-): GetRecipientResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | Recipient id |
-| `request` | [`UpdateRecipientBankAccountRequest`](/doc/models/update-recipient-bank-account-request.md) | Body, Required | Bank account data |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetRecipientResponse`](/doc/models/get-recipient-response.md)
-
-## Example Usage
-
-```php
-$recipientId = 'recipient_id0';
-$request_bankAccount_holderName = 'holder_name6';
-$request_bankAccount_holderType = 'holder_type2';
-$request_bankAccount_holderDocument = 'holder_document4';
-$request_bankAccount_bank = 'bank8';
-$request_bankAccount_branchNumber = 'branch_number6';
-$request_bankAccount_branchCheckDigit = 'branch_check_digit6';
-$request_bankAccount_accountNumber = 'account_number0';
-$request_bankAccount_accountCheckDigit = 'account_check_digit6';
-$request_bankAccount_type = 'type0';
-$request_bankAccount_metadata = ['key0' => 'metadata9', 'key1' => 'metadata8'];
-$request_bankAccount_pixKey = 'pix_key4';
-$request_bankAccount = new Models\CreateBankAccountRequest(
-    $request_bankAccount_holderName,
-    $request_bankAccount_holderType,
-    $request_bankAccount_holderDocument,
-    $request_bankAccount_bank,
-    $request_bankAccount_branchNumber,
-    $request_bankAccount_branchCheckDigit,
-    $request_bankAccount_accountNumber,
-    $request_bankAccount_accountCheckDigit,
-    $request_bankAccount_type,
-    $request_bankAccount_metadata,
-    $request_bankAccount_pixKey
-);
-$request_paymentMode = 'bank_transfer';
-$request = new Models\UpdateRecipientBankAccountRequest(
-    $request_bankAccount,
-    $request_paymentMode
-);
-
-$result = $recipientsController->updateRecipientDefaultBankAccount($recipientId, $request);
-```
-
-
 # Update Recipient Metadata
 
 Updates recipient metadata
@@ -308,45 +219,6 @@ $result = $recipientsController->updateRecipientMetadata($recipientId, $request)
 ```
 
 
-# Get Transfers
-
-Gets a paginated list of transfers for the recipient
-
-```php
-function getTransfers(
-    string $recipientId,
-    ?int $page = null,
-    ?int $size = null,
-    ?string $status = null,
-    ?\DateTime $createdSince = null,
-    ?\DateTime $createdUntil = null
-): ListTransferResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | Recipient id |
-| `page` | `?int` | Query, Optional | Page number |
-| `size` | `?int` | Query, Optional | Page size |
-| `status` | `?string` | Query, Optional | Filter for transfer status |
-| `createdSince` | `?\DateTime` | Query, Optional | Filter for start range of transfer creation date |
-| `createdUntil` | `?\DateTime` | Query, Optional | Filter for end range of transfer creation date |
-
-## Response Type
-
-[`ListTransferResponse`](/doc/models/list-transfer-response.md)
-
-## Example Usage
-
-```php
-$recipientId = 'recipient_id0';
-
-$result = $recipientsController->getTransfers($recipientId);
-```
-
-
 # Get Transfer
 
 Gets a transfer
@@ -373,70 +245,6 @@ $recipientId = 'recipient_id0';
 $transferId = 'transfer_id6';
 
 $result = $recipientsController->getTransfer($recipientId, $transferId);
-```
-
-
-# Create Withdraw
-
-```php
-function createWithdraw(string $recipientId, CreateWithdrawRequest $request): GetWithdrawResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | - |
-| `request` | [`CreateWithdrawRequest`](/doc/models/create-withdraw-request.md) | Body, Required | - |
-
-## Response Type
-
-[`GetWithdrawResponse`](/doc/models/get-withdraw-response.md)
-
-## Example Usage
-
-```php
-$recipientId = 'recipient_id0';
-$request_amount = 242;
-$request = new Models\CreateWithdrawRequest(
-    $request_amount
-);
-
-$result = $recipientsController->createWithdraw($recipientId, $request);
-```
-
-
-# Update Automatic Anticipation Settings
-
-Updates recipient metadata
-
-```php
-function updateAutomaticAnticipationSettings(
-    string $recipientId,
-    UpdateAutomaticAnticipationSettingsRequest $request,
-    ?string $idempotencyKey = null
-): GetRecipientResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | Recipient id |
-| `request` | [`UpdateAutomaticAnticipationSettingsRequest`](/doc/models/update-automatic-anticipation-settings-request.md) | Body, Required | Metadata |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetRecipientResponse`](/doc/models/get-recipient-response.md)
-
-## Example Usage
-
-```php
-$recipientId = 'recipient_id0';
-$request = new Models\UpdateAutomaticAnticipationSettingsRequest;
-
-$result = $recipientsController->updateAutomaticAnticipationSettings($recipientId, $request);
 ```
 
 
@@ -553,19 +361,25 @@ $result = $recipientsController->getAnticipations($recipientId);
 ```
 
 
-# Get Recipient
+# Update Recipient Default Bank Account
 
-Retrieves recipient information
+Updates the default bank account from a recipient
 
 ```php
-function getRecipient(string $recipientId): GetRecipientResponse
+function updateRecipientDefaultBankAccount(
+    string $recipientId,
+    UpdateRecipientBankAccountRequest $request,
+    ?string $idempotencyKey = null
+): GetRecipientResponse
 ```
 
 ## Parameters
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | Recipiend id |
+| `recipientId` | `string` | Template, Required | Recipient id |
+| `request` | [`UpdateRecipientBankAccountRequest`](/doc/models/update-recipient-bank-account-request.md) | Body, Required | Bank account data |
+| `idempotencyKey` | `?string` | Header, Optional | - |
 
 ## Response Type
 
@@ -575,8 +389,67 @@ function getRecipient(string $recipientId): GetRecipientResponse
 
 ```php
 $recipientId = 'recipient_id0';
+$request_bankAccount_holderName = 'holder_name6';
+$request_bankAccount_holderType = 'holder_type2';
+$request_bankAccount_holderDocument = 'holder_document4';
+$request_bankAccount_bank = 'bank8';
+$request_bankAccount_branchNumber = 'branch_number6';
+$request_bankAccount_branchCheckDigit = 'branch_check_digit6';
+$request_bankAccount_accountNumber = 'account_number0';
+$request_bankAccount_accountCheckDigit = 'account_check_digit6';
+$request_bankAccount_type = 'type0';
+$request_bankAccount_metadata = ['key0' => 'metadata9', 'key1' => 'metadata8'];
+$request_bankAccount_pixKey = 'pix_key4';
+$request_bankAccount = new Models\CreateBankAccountRequest(
+    $request_bankAccount_holderName,
+    $request_bankAccount_holderType,
+    $request_bankAccount_holderDocument,
+    $request_bankAccount_bank,
+    $request_bankAccount_branchNumber,
+    $request_bankAccount_branchCheckDigit,
+    $request_bankAccount_accountNumber,
+    $request_bankAccount_accountCheckDigit,
+    $request_bankAccount_type,
+    $request_bankAccount_metadata,
+    $request_bankAccount_pixKey
+);
+$request_paymentMode = 'bank_transfer';
+$request = new Models\UpdateRecipientBankAccountRequest(
+    $request_bankAccount,
+    $request_paymentMode
+);
 
-$result = $recipientsController->getRecipient($recipientId);
+$result = $recipientsController->updateRecipientDefaultBankAccount($recipientId, $request);
+```
+
+
+# Create Withdraw
+
+```php
+function createWithdraw(string $recipientId, CreateWithdrawRequest $request): GetWithdrawResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `string` | Template, Required | - |
+| `request` | [`CreateWithdrawRequest`](/doc/models/create-withdraw-request.md) | Body, Required | - |
+
+## Response Type
+
+[`GetWithdrawResponse`](/doc/models/get-withdraw-response.md)
+
+## Example Usage
+
+```php
+$recipientId = 'recipient_id0';
+$request_amount = 242;
+$request = new Models\CreateWithdrawRequest(
+    $request_amount
+);
+
+$result = $recipientsController->createWithdraw($recipientId, $request);
 ```
 
 
@@ -604,45 +477,6 @@ function getBalance(string $recipientId): GetBalanceResponse
 $recipientId = 'recipient_id0';
 
 $result = $recipientsController->getBalance($recipientId);
-```
-
-
-# Get Withdrawals
-
-Gets a paginated list of transfers for the recipient
-
-```php
-function getWithdrawals(
-    string $recipientId,
-    ?int $page = null,
-    ?int $size = null,
-    ?string $status = null,
-    ?\DateTime $createdSince = null,
-    ?\DateTime $createdUntil = null
-): ListWithdrawals
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | - |
-| `page` | `?int` | Query, Optional | - |
-| `size` | `?int` | Query, Optional | - |
-| `status` | `?string` | Query, Optional | - |
-| `createdSince` | `?\DateTime` | Query, Optional | - |
-| `createdUntil` | `?\DateTime` | Query, Optional | - |
-
-## Response Type
-
-[`ListWithdrawals`](/doc/models/list-withdrawals.md)
-
-## Example Usage
-
-```php
-$recipientId = 'recipient_id0';
-
-$result = $recipientsController->getWithdrawals($recipientId);
 ```
 
 
@@ -752,6 +586,172 @@ $request = new Models\CreateRecipientRequest(
 );
 
 $result = $recipientsController->createRecipient($request);
+```
+
+
+# Update Automatic Anticipation Settings
+
+Updates recipient metadata
+
+```php
+function updateAutomaticAnticipationSettings(
+    string $recipientId,
+    UpdateAutomaticAnticipationSettingsRequest $request,
+    ?string $idempotencyKey = null
+): GetRecipientResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `string` | Template, Required | Recipient id |
+| `request` | [`UpdateAutomaticAnticipationSettingsRequest`](/doc/models/update-automatic-anticipation-settings-request.md) | Body, Required | Metadata |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetRecipientResponse`](/doc/models/get-recipient-response.md)
+
+## Example Usage
+
+```php
+$recipientId = 'recipient_id0';
+$request = new Models\UpdateAutomaticAnticipationSettingsRequest;
+
+$result = $recipientsController->updateAutomaticAnticipationSettings($recipientId, $request);
+```
+
+
+# Get Recipient
+
+Retrieves recipient information
+
+```php
+function getRecipient(string $recipientId): GetRecipientResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `string` | Template, Required | Recipiend id |
+
+## Response Type
+
+[`GetRecipientResponse`](/doc/models/get-recipient-response.md)
+
+## Example Usage
+
+```php
+$recipientId = 'recipient_id0';
+
+$result = $recipientsController->getRecipient($recipientId);
+```
+
+
+# Get Withdrawals
+
+Gets a paginated list of transfers for the recipient
+
+```php
+function getWithdrawals(
+    string $recipientId,
+    ?int $page = null,
+    ?int $size = null,
+    ?string $status = null,
+    ?\DateTime $createdSince = null,
+    ?\DateTime $createdUntil = null
+): ListWithdrawals
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `string` | Template, Required | - |
+| `page` | `?int` | Query, Optional | - |
+| `size` | `?int` | Query, Optional | - |
+| `status` | `?string` | Query, Optional | - |
+| `createdSince` | `?\DateTime` | Query, Optional | - |
+| `createdUntil` | `?\DateTime` | Query, Optional | - |
+
+## Response Type
+
+[`ListWithdrawals`](/doc/models/list-withdrawals.md)
+
+## Example Usage
+
+```php
+$recipientId = 'recipient_id0';
+
+$result = $recipientsController->getWithdrawals($recipientId);
+```
+
+
+# Get Withdraw by Id
+
+```php
+function getWithdrawById(string $recipientId, string $withdrawalId): GetWithdrawResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `string` | Template, Required | - |
+| `withdrawalId` | `string` | Template, Required | - |
+
+## Response Type
+
+[`GetWithdrawResponse`](/doc/models/get-withdraw-response.md)
+
+## Example Usage
+
+```php
+$recipientId = 'recipient_id0';
+$withdrawalId = 'withdrawal_id2';
+
+$result = $recipientsController->getWithdrawById($recipientId, $withdrawalId);
+```
+
+
+# Get Transfers
+
+Gets a paginated list of transfers for the recipient
+
+```php
+function getTransfers(
+    string $recipientId,
+    ?int $page = null,
+    ?int $size = null,
+    ?string $status = null,
+    ?\DateTime $createdSince = null,
+    ?\DateTime $createdUntil = null
+): ListTransferResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `string` | Template, Required | Recipient id |
+| `page` | `?int` | Query, Optional | Page number |
+| `size` | `?int` | Query, Optional | Page size |
+| `status` | `?string` | Query, Optional | Filter for transfer status |
+| `createdSince` | `?\DateTime` | Query, Optional | Filter for start range of transfer creation date |
+| `createdUntil` | `?\DateTime` | Query, Optional | Filter for end range of transfer creation date |
+
+## Response Type
+
+[`ListTransferResponse`](/doc/models/list-transfer-response.md)
+
+## Example Usage
+
+```php
+$recipientId = 'recipient_id0';
+
+$result = $recipientsController->getTransfers($recipientId);
 ```
 
 

--- a/doc/controllers/subscriptions.md
+++ b/doc/controllers/subscriptions.md
@@ -11,39 +11,39 @@ $subscriptionsController = $client->getSubscriptionsController();
 ## Methods
 
 * [Renew Subscription](/doc/controllers/subscriptions.md#renew-subscription)
-* [Update Subscription Card](/doc/controllers/subscriptions.md#update-subscription-card)
-* [Delete Usage](/doc/controllers/subscriptions.md#delete-usage)
-* [Create Discount](/doc/controllers/subscriptions.md#create-discount)
-* [Create an Usage](/doc/controllers/subscriptions.md#create-an-usage)
-* [Update Current Cycle Status](/doc/controllers/subscriptions.md#update-current-cycle-status)
 * [Delete Discount](/doc/controllers/subscriptions.md#delete-discount)
-* [Get Subscription Items](/doc/controllers/subscriptions.md#get-subscription-items)
-* [Update Subscription Payment Method](/doc/controllers/subscriptions.md#update-subscription-payment-method)
-* [Get Subscription Item](/doc/controllers/subscriptions.md#get-subscription-item)
 * [Get Subscriptions](/doc/controllers/subscriptions.md#get-subscriptions)
-* [Cancel Subscription](/doc/controllers/subscriptions.md#cancel-subscription)
-* [Create Increment](/doc/controllers/subscriptions.md#create-increment)
-* [Create Usage](/doc/controllers/subscriptions.md#create-usage)
 * [Get Discount by Id](/doc/controllers/subscriptions.md#get-discount-by-id)
 * [Create Subscription](/doc/controllers/subscriptions.md#create-subscription)
 * [Get Increment by Id](/doc/controllers/subscriptions.md#get-increment-by-id)
-* [Update Subscription Affiliation Id](/doc/controllers/subscriptions.md#update-subscription-affiliation-id)
 * [Update Subscription Metadata](/doc/controllers/subscriptions.md#update-subscription-metadata)
 * [Delete Increment](/doc/controllers/subscriptions.md#delete-increment)
-* [Get Subscription Cycles](/doc/controllers/subscriptions.md#get-subscription-cycles)
+* [Get Subscription](/doc/controllers/subscriptions.md#get-subscription)
+* [Update Latest Period End At](/doc/controllers/subscriptions.md#update-latest-period-end-at)
+* [Update Current Cycle Status](/doc/controllers/subscriptions.md#update-current-cycle-status)
+* [Get Subscription Items](/doc/controllers/subscriptions.md#get-subscription-items)
+* [Get Subscription Item](/doc/controllers/subscriptions.md#get-subscription-item)
+* [Update Subscription Affiliation Id](/doc/controllers/subscriptions.md#update-subscription-affiliation-id)
 * [Get Discounts](/doc/controllers/subscriptions.md#get-discounts)
-* [Update Subscription Billing Date](/doc/controllers/subscriptions.md#update-subscription-billing-date)
+* [Update Subscription Item](/doc/controllers/subscriptions.md#update-subscription-item)
+* [Create Subscription Item](/doc/controllers/subscriptions.md#create-subscription-item)
+* [Get Usages](/doc/controllers/subscriptions.md#get-usages)
+* [Update Subscription Minium Price](/doc/controllers/subscriptions.md#update-subscription-minium-price)
+* [Get Subscription Cycle by Id](/doc/controllers/subscriptions.md#get-subscription-cycle-by-id)
+* [Create an Usage](/doc/controllers/subscriptions.md#create-an-usage)
+* [Cancel Subscription](/doc/controllers/subscriptions.md#cancel-subscription)
 * [Delete Subscription Item](/doc/controllers/subscriptions.md#delete-subscription-item)
 * [Get Increments](/doc/controllers/subscriptions.md#get-increments)
 * [Update Subscription Due Days](/doc/controllers/subscriptions.md#update-subscription-due-days)
+* [Update Subscription Card](/doc/controllers/subscriptions.md#update-subscription-card)
+* [Delete Usage](/doc/controllers/subscriptions.md#delete-usage)
+* [Create Discount](/doc/controllers/subscriptions.md#create-discount)
+* [Update Subscription Payment Method](/doc/controllers/subscriptions.md#update-subscription-payment-method)
+* [Create Increment](/doc/controllers/subscriptions.md#create-increment)
+* [Create Usage](/doc/controllers/subscriptions.md#create-usage)
+* [Get Subscription Cycles](/doc/controllers/subscriptions.md#get-subscription-cycles)
+* [Update Subscription Billing Date](/doc/controllers/subscriptions.md#update-subscription-billing-date)
 * [Update Subscription Start At](/doc/controllers/subscriptions.md#update-subscription-start-at)
-* [Update Subscription Item](/doc/controllers/subscriptions.md#update-subscription-item)
-* [Create Subscription Item](/doc/controllers/subscriptions.md#create-subscription-item)
-* [Get Subscription](/doc/controllers/subscriptions.md#get-subscription)
-* [Get Usages](/doc/controllers/subscriptions.md#get-usages)
-* [Update Latest Period End At](/doc/controllers/subscriptions.md#update-latest-period-end-at)
-* [Update Subscription Minium Price](/doc/controllers/subscriptions.md#update-subscription-minium-price)
-* [Get Subscription Cycle by Id](/doc/controllers/subscriptions.md#get-subscription-cycle-by-id)
 * [Get Usage Report](/doc/controllers/subscriptions.md#get-usage-report)
 
 
@@ -70,241 +70,6 @@ function renewSubscription(string $subscriptionId, ?string $idempotencyKey = nul
 $subscriptionId = 'subscription_id0';
 
 $result = $subscriptionsController->renewSubscription($subscriptionId);
-```
-
-
-# Update Subscription Card
-
-Updates the credit card from a subscription
-
-```php
-function updateSubscriptionCard(
-    string $subscriptionId,
-    UpdateSubscriptionCardRequest $request,
-    ?string $idempotencyKey = null
-): GetSubscriptionResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `request` | [`UpdateSubscriptionCardRequest`](/doc/models/update-subscription-card-request.md) | Body, Required | Request for updating a card |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$request_card_number = 'number2';
-$request_card_holderName = 'holder_name6';
-$request_card_expMonth = 80;
-$request_card_expYear = 216;
-$request_card_cvv = 'cvv8';
-$request_card_billingAddress_street = 'street2';
-$request_card_billingAddress_number = 'number0';
-$request_card_billingAddress_zipCode = 'zip_code6';
-$request_card_billingAddress_neighborhood = 'neighborhood8';
-$request_card_billingAddress_city = 'city8';
-$request_card_billingAddress_state = 'state2';
-$request_card_billingAddress_country = 'country6';
-$request_card_billingAddress_complement = 'complement2';
-$request_card_billingAddress_metadata = ['key0' => 'metadata1'];
-$request_card_billingAddress_line1 = 'line_14';
-$request_card_billingAddress_line2 = 'line_20';
-$request_card_billingAddress = new Models\CreateAddressRequest(
-    $request_card_billingAddress_street,
-    $request_card_billingAddress_number,
-    $request_card_billingAddress_zipCode,
-    $request_card_billingAddress_neighborhood,
-    $request_card_billingAddress_city,
-    $request_card_billingAddress_state,
-    $request_card_billingAddress_country,
-    $request_card_billingAddress_complement,
-    $request_card_billingAddress_metadata,
-    $request_card_billingAddress_line1,
-    $request_card_billingAddress_line2
-);
-$request_card_brand = 'brand4';
-$request_card_billingAddressId = 'billing_address_id6';
-$request_card_metadata = ['key0' => 'metadata3', 'key1' => 'metadata4', 'key2' => 'metadata5'];
-$request_card_type = 'credit';
-$request_card_options_verifyCard = false;
-$request_card_options = new Models\CreateCardOptionsRequest(
-    $request_card_options_verifyCard
-);
-$request_card_privateLabel = false;
-$request_card_label = 'label0';
-$request_card = new Models\CreateCardRequest(
-    $request_card_number,
-    $request_card_holderName,
-    $request_card_expMonth,
-    $request_card_expYear,
-    $request_card_cvv,
-    $request_card_billingAddress,
-    $request_card_brand,
-    $request_card_billingAddressId,
-    $request_card_metadata,
-    $request_card_type,
-    $request_card_options,
-    $request_card_privateLabel,
-    $request_card_label
-);
-$request_cardId = 'card_id2';
-$request = new Models\UpdateSubscriptionCardRequest(
-    $request_card,
-    $request_cardId
-);
-
-$result = $subscriptionsController->updateSubscriptionCard($subscriptionId, $request);
-```
-
-
-# Delete Usage
-
-Deletes a usage
-
-```php
-function deleteUsage(
-    string $subscriptionId,
-    string $itemId,
-    string $usageId,
-    ?string $idempotencyKey = null
-): GetUsageResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | The subscription id |
-| `itemId` | `string` | Template, Required | The subscription item id |
-| `usageId` | `string` | Template, Required | The usage id |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetUsageResponse`](/doc/models/get-usage-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$itemId = 'item_id0';
-$usageId = 'usage_id0';
-
-$result = $subscriptionsController->deleteUsage($subscriptionId, $itemId, $usageId);
-```
-
-
-# Create Discount
-
-Creates a discount
-
-```php
-function createDiscount(
-    string $subscriptionId,
-    CreateDiscountRequest $request,
-    ?string $idempotencyKey = null
-): GetDiscountResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `request` | [`CreateDiscountRequest`](/doc/models/create-discount-request.md) | Body, Required | Request for creating a discount |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetDiscountResponse`](/doc/models/get-discount-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$request_value = 185.28;
-$request_discountType = 'discount_type4';
-$request_itemId = 'item_id6';
-$request = new Models\CreateDiscountRequest(
-    $request_value,
-    $request_discountType,
-    $request_itemId
-);
-
-$result = $subscriptionsController->createDiscount($subscriptionId, $request);
-```
-
-
-# Create an Usage
-
-Create Usage
-
-```php
-function createAnUsage(string $subscriptionId, string $itemId, ?string $idempotencyKey = null): GetUsageResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `itemId` | `string` | Template, Required | Item id |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetUsageResponse`](/doc/models/get-usage-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$itemId = 'item_id0';
-
-$result = $subscriptionsController->createAnUsage($subscriptionId, $itemId);
-```
-
-
-# Update Current Cycle Status
-
-```php
-function updateCurrentCycleStatus(
-    string $subscriptionId,
-    UpdateCurrentCycleStatusRequest $request,
-    ?string $idempotencyKey = null
-): void
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription Id |
-| `request` | [`UpdateCurrentCycleStatusRequest`](/doc/models/update-current-cycle-status-request.md) | Body, Required | Request for updating the end date of the subscription current status |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-`void`
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$request_status = 'status8';
-$request = new Models\UpdateCurrentCycleStatusRequest(
-    $request_status
-);
-
-$subscriptionsController->updateCurrentCycleStatus($subscriptionId, $request);
 ```
 
 
@@ -339,174 +104,6 @@ $subscriptionId = 'subscription_id0';
 $discountId = 'discount_id8';
 
 $result = $subscriptionsController->deleteDiscount($subscriptionId, $discountId);
-```
-
-
-# Get Subscription Items
-
-Get Subscription Items
-
-```php
-function getSubscriptionItems(
-    string $subscriptionId,
-    ?int $page = null,
-    ?int $size = null,
-    ?string $name = null,
-    ?string $code = null,
-    ?string $status = null,
-    ?string $description = null,
-    ?string $createdSince = null,
-    ?string $createdUntil = null
-): ListSubscriptionItemsResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | The subscription id |
-| `page` | `?int` | Query, Optional | Page number |
-| `size` | `?int` | Query, Optional | Page size |
-| `name` | `?string` | Query, Optional | The item name |
-| `code` | `?string` | Query, Optional | Identification code in the client system |
-| `status` | `?string` | Query, Optional | The item statis |
-| `description` | `?string` | Query, Optional | The item description |
-| `createdSince` | `?string` | Query, Optional | Filter for item's creation date start range |
-| `createdUntil` | `?string` | Query, Optional | Filter for item's creation date end range |
-
-## Response Type
-
-[`ListSubscriptionItemsResponse`](/doc/models/list-subscription-items-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-
-$result = $subscriptionsController->getSubscriptionItems($subscriptionId);
-```
-
-
-# Update Subscription Payment Method
-
-Updates the payment method from a subscription
-
-```php
-function updateSubscriptionPaymentMethod(
-    string $subscriptionId,
-    UpdateSubscriptionPaymentMethodRequest $request,
-    ?string $idempotencyKey = null
-): GetSubscriptionResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `request` | [`UpdateSubscriptionPaymentMethodRequest`](/doc/models/update-subscription-payment-method-request.md) | Body, Required | Request for updating the paymentmethod from a subscription |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$request_paymentMethod = 'payment_method4';
-$request_cardId = 'card_id2';
-$request_card_number = 'number2';
-$request_card_holderName = 'holder_name6';
-$request_card_expMonth = 80;
-$request_card_expYear = 216;
-$request_card_cvv = 'cvv8';
-$request_card_billingAddress_street = 'street2';
-$request_card_billingAddress_number = 'number0';
-$request_card_billingAddress_zipCode = 'zip_code6';
-$request_card_billingAddress_neighborhood = 'neighborhood8';
-$request_card_billingAddress_city = 'city8';
-$request_card_billingAddress_state = 'state2';
-$request_card_billingAddress_country = 'country6';
-$request_card_billingAddress_complement = 'complement2';
-$request_card_billingAddress_metadata = ['key0' => 'metadata1'];
-$request_card_billingAddress_line1 = 'line_14';
-$request_card_billingAddress_line2 = 'line_20';
-$request_card_billingAddress = new Models\CreateAddressRequest(
-    $request_card_billingAddress_street,
-    $request_card_billingAddress_number,
-    $request_card_billingAddress_zipCode,
-    $request_card_billingAddress_neighborhood,
-    $request_card_billingAddress_city,
-    $request_card_billingAddress_state,
-    $request_card_billingAddress_country,
-    $request_card_billingAddress_complement,
-    $request_card_billingAddress_metadata,
-    $request_card_billingAddress_line1,
-    $request_card_billingAddress_line2
-);
-$request_card_brand = 'brand4';
-$request_card_billingAddressId = 'billing_address_id6';
-$request_card_metadata = ['key0' => 'metadata3', 'key1' => 'metadata4', 'key2' => 'metadata5'];
-$request_card_type = 'credit';
-$request_card_options_verifyCard = false;
-$request_card_options = new Models\CreateCardOptionsRequest(
-    $request_card_options_verifyCard
-);
-$request_card_privateLabel = false;
-$request_card_label = 'label0';
-$request_card = new Models\CreateCardRequest(
-    $request_card_number,
-    $request_card_holderName,
-    $request_card_expMonth,
-    $request_card_expYear,
-    $request_card_cvv,
-    $request_card_billingAddress,
-    $request_card_brand,
-    $request_card_billingAddressId,
-    $request_card_metadata,
-    $request_card_type,
-    $request_card_options,
-    $request_card_privateLabel,
-    $request_card_label
-);
-$request = new Models\UpdateSubscriptionPaymentMethodRequest(
-    $request_paymentMethod,
-    $request_cardId,
-    $request_card
-);
-
-$result = $subscriptionsController->updateSubscriptionPaymentMethod($subscriptionId, $request);
-```
-
-
-# Get Subscription Item
-
-Get Subscription Item
-
-```php
-function getSubscriptionItem(string $subscriptionId, string $itemId): GetSubscriptionItemResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription Id |
-| `itemId` | `string` | Template, Required | Item id |
-
-## Response Type
-
-[`GetSubscriptionItemResponse`](/doc/models/get-subscription-item-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$itemId = 'item_id0';
-
-$result = $subscriptionsController->getSubscriptionItem($subscriptionId, $itemId);
 ```
 
 
@@ -556,128 +153,6 @@ function getSubscriptions(
 
 ```php
 $result = $subscriptionsController->getSubscriptions();
-```
-
-
-# Cancel Subscription
-
-Cancels a subscription
-
-```php
-function cancelSubscription(
-    string $subscriptionId,
-    ?CreateCancelSubscriptionRequest $request = null,
-    ?string $idempotencyKey = null
-): GetSubscriptionResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `request` | [`?CreateCancelSubscriptionRequest`](/doc/models/create-cancel-subscription-request.md) | Body, Optional | Request for cancelling a subscription |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$request_cancelPendingInvoices = true;
-$request = new Models\CreateCancelSubscriptionRequest(
-    $request_cancelPendingInvoices
-);
-
-$result = $subscriptionsController->cancelSubscription($subscriptionId, $request);
-```
-
-
-# Create Increment
-
-Creates a increment
-
-```php
-function createIncrement(
-    string $subscriptionId,
-    CreateIncrementRequest $request,
-    ?string $idempotencyKey = null
-): GetIncrementResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `request` | [`CreateIncrementRequest`](/doc/models/create-increment-request.md) | Body, Required | Request for creating a increment |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetIncrementResponse`](/doc/models/get-increment-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$request_value = 185.28;
-$request_incrementType = 'increment_type8';
-$request_itemId = 'item_id6';
-$request = new Models\CreateIncrementRequest(
-    $request_value,
-    $request_incrementType,
-    $request_itemId
-);
-
-$result = $subscriptionsController->createIncrement($subscriptionId, $request);
-```
-
-
-# Create Usage
-
-Creates a usage
-
-```php
-function createUsage(
-    string $subscriptionId,
-    string $itemId,
-    CreateUsageRequest $body,
-    ?string $idempotencyKey = null
-): GetUsageResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription Id |
-| `itemId` | `string` | Template, Required | Item id |
-| `body` | [`CreateUsageRequest`](/doc/models/create-usage-request.md) | Body, Required | Request for creating a usage |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetUsageResponse`](/doc/models/get-usage-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$itemId = 'item_id0';
-$body_quantity = 156;
-$body_description = 'description4';
-$body_usedAt = DateTimeHelper::fromRfc3339DateTime('2016-03-13T12:52:32.123Z');
-$body = new Models\CreateUsageRequest(
-    $body_quantity,
-    $body_description,
-    $body_usedAt
-);
-
-$result = $subscriptionsController->createUsage($subscriptionId, $itemId, $body);
 ```
 
 
@@ -1167,41 +642,6 @@ $result = $subscriptionsController->getIncrementById($subscriptionId, $increment
 ```
 
 
-# Update Subscription Affiliation Id
-
-```php
-function updateSubscriptionAffiliationId(
-    string $subscriptionId,
-    UpdateSubscriptionAffiliationIdRequest $request,
-    ?string $idempotencyKey = null
-): GetSubscriptionResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | - |
-| `request` | [`UpdateSubscriptionAffiliationIdRequest`](/doc/models/update-subscription-affiliation-id-request.md) | Body, Required | Request for updating a subscription affiliation id |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$request_gatewayAffiliationId = 'gateway_affiliation_id2';
-$request = new Models\UpdateSubscriptionAffiliationIdRequest(
-    $request_gatewayAffiliationId
-);
-
-$result = $subscriptionsController->updateSubscriptionAffiliationId($subscriptionId, $request);
-```
-
-
 # Update Subscription Metadata
 
 Updates the metadata from a subscription
@@ -1273,10 +713,73 @@ $result = $subscriptionsController->deleteIncrement($subscriptionId, $incrementI
 ```
 
 
-# Get Subscription Cycles
+# Get Subscription
+
+Gets a subscription
 
 ```php
-function getSubscriptionCycles(string $subscriptionId, string $page, string $size): ListCyclesResponse
+function getSubscription(string $subscriptionId): GetSubscriptionResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+
+$result = $subscriptionsController->getSubscription($subscriptionId);
+```
+
+
+# Update Latest Period End At
+
+```php
+function updateLatestPeriodEndAt(
+    string $subscriptionId,
+    UpdateCurrentCycleEndDateRequest $request,
+    ?string $idempotencyKey = null
+): GetSubscriptionResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | - |
+| `request` | [`UpdateCurrentCycleEndDateRequest`](/doc/models/update-current-cycle-end-date-request.md) | Body, Required | Request for updating the end date of the current signature cycle |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$request = new Models\UpdateCurrentCycleEndDateRequest;
+
+$result = $subscriptionsController->updateLatestPeriodEndAt($subscriptionId, $request);
+```
+
+
+# Update Current Cycle Status
+
+```php
+function updateCurrentCycleStatus(
+    string $subscriptionId,
+    UpdateCurrentCycleStatusRequest $request,
+    ?string $idempotencyKey = null
+): void
 ```
 
 ## Parameters
@@ -1284,21 +787,132 @@ function getSubscriptionCycles(string $subscriptionId, string $page, string $siz
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
 | `subscriptionId` | `string` | Template, Required | Subscription Id |
-| `page` | `string` | Query, Required | Page number |
-| `size` | `string` | Query, Required | Page size |
+| `request` | [`UpdateCurrentCycleStatusRequest`](/doc/models/update-current-cycle-status-request.md) | Body, Required | Request for updating the end date of the subscription current status |
+| `idempotencyKey` | `?string` | Header, Optional | - |
 
 ## Response Type
 
-[`ListCyclesResponse`](/doc/models/list-cycles-response.md)
+`void`
 
 ## Example Usage
 
 ```php
 $subscriptionId = 'subscription_id0';
-$page = 'page8';
-$size = 'size0';
+$request_status = 'status8';
+$request = new Models\UpdateCurrentCycleStatusRequest(
+    $request_status
+);
 
-$result = $subscriptionsController->getSubscriptionCycles($subscriptionId, $page, $size);
+$subscriptionsController->updateCurrentCycleStatus($subscriptionId, $request);
+```
+
+
+# Get Subscription Items
+
+Get Subscription Items
+
+```php
+function getSubscriptionItems(
+    string $subscriptionId,
+    ?int $page = null,
+    ?int $size = null,
+    ?string $name = null,
+    ?string $code = null,
+    ?string $status = null,
+    ?string $description = null,
+    ?string $createdSince = null,
+    ?string $createdUntil = null
+): ListSubscriptionItemsResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | The subscription id |
+| `page` | `?int` | Query, Optional | Page number |
+| `size` | `?int` | Query, Optional | Page size |
+| `name` | `?string` | Query, Optional | The item name |
+| `code` | `?string` | Query, Optional | Identification code in the client system |
+| `status` | `?string` | Query, Optional | The item statis |
+| `description` | `?string` | Query, Optional | The item description |
+| `createdSince` | `?string` | Query, Optional | Filter for item's creation date start range |
+| `createdUntil` | `?string` | Query, Optional | Filter for item's creation date end range |
+
+## Response Type
+
+[`ListSubscriptionItemsResponse`](/doc/models/list-subscription-items-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+
+$result = $subscriptionsController->getSubscriptionItems($subscriptionId);
+```
+
+
+# Get Subscription Item
+
+Get Subscription Item
+
+```php
+function getSubscriptionItem(string $subscriptionId, string $itemId): GetSubscriptionItemResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription Id |
+| `itemId` | `string` | Template, Required | Item id |
+
+## Response Type
+
+[`GetSubscriptionItemResponse`](/doc/models/get-subscription-item-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$itemId = 'item_id0';
+
+$result = $subscriptionsController->getSubscriptionItem($subscriptionId, $itemId);
+```
+
+
+# Update Subscription Affiliation Id
+
+```php
+function updateSubscriptionAffiliationId(
+    string $subscriptionId,
+    UpdateSubscriptionAffiliationIdRequest $request,
+    ?string $idempotencyKey = null
+): GetSubscriptionResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | - |
+| `request` | [`UpdateSubscriptionAffiliationIdRequest`](/doc/models/update-subscription-affiliation-id-request.md) | Body, Required | Request for updating a subscription affiliation id |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$request_gatewayAffiliationId = 'gateway_affiliation_id2';
+$request = new Models\UpdateSubscriptionAffiliationIdRequest(
+    $request_gatewayAffiliationId
+);
+
+$result = $subscriptionsController->updateSubscriptionAffiliationId($subscriptionId, $request);
 ```
 
 
@@ -1328,178 +942,6 @@ $page = 30;
 $size = 18;
 
 $result = $subscriptionsController->getDiscounts($subscriptionId, $page, $size);
-```
-
-
-# Update Subscription Billing Date
-
-Updates the billing date from a subscription
-
-```php
-function updateSubscriptionBillingDate(
-    string $subscriptionId,
-    UpdateSubscriptionBillingDateRequest $request,
-    ?string $idempotencyKey = null
-): GetSubscriptionResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | The subscription id |
-| `request` | [`UpdateSubscriptionBillingDateRequest`](/doc/models/update-subscription-billing-date-request.md) | Body, Required | Request for updating the subscription billing date |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$request_nextBillingAt = DateTimeHelper::fromRfc3339DateTime('2016-03-13T12:52:32.123Z');
-$request = new Models\UpdateSubscriptionBillingDateRequest(
-    $request_nextBillingAt
-);
-
-$result = $subscriptionsController->updateSubscriptionBillingDate($subscriptionId, $request);
-```
-
-
-# Delete Subscription Item
-
-Deletes a subscription item
-
-```php
-function deleteSubscriptionItem(
-    string $subscriptionId,
-    string $subscriptionItemId,
-    ?string $idempotencyKey = null
-): GetSubscriptionItemResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `subscriptionItemId` | `string` | Template, Required | Subscription item id |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionItemResponse`](/doc/models/get-subscription-item-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$subscriptionItemId = 'subscription_item_id4';
-
-$result = $subscriptionsController->deleteSubscriptionItem($subscriptionId, $subscriptionItemId);
-```
-
-
-# Get Increments
-
-```php
-function getIncrements(string $subscriptionId, ?int $page = null, ?int $size = null): ListIncrementsResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | The subscription id |
-| `page` | `?int` | Query, Optional | Page number |
-| `size` | `?int` | Query, Optional | Page size |
-
-## Response Type
-
-[`ListIncrementsResponse`](/doc/models/list-increments-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-
-$result = $subscriptionsController->getIncrements($subscriptionId);
-```
-
-
-# Update Subscription Due Days
-
-Updates the boleto due days from a subscription
-
-```php
-function updateSubscriptionDueDays(
-    string $subscriptionId,
-    UpdateSubscriptionDueDaysRequest $request,
-    ?string $idempotencyKey = null
-): GetSubscriptionResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription Id |
-| `request` | [`UpdateSubscriptionDueDaysRequest`](/doc/models/update-subscription-due-days-request.md) | Body, Required | - |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$request_boletoDueDays = 226;
-$request = new Models\UpdateSubscriptionDueDaysRequest(
-    $request_boletoDueDays
-);
-
-$result = $subscriptionsController->updateSubscriptionDueDays($subscriptionId, $request);
-```
-
-
-# Update Subscription Start At
-
-Updates the start at date from a subscription
-
-```php
-function updateSubscriptionStartAt(
-    string $subscriptionId,
-    UpdateSubscriptionStartAtRequest $request,
-    ?string $idempotencyKey = null
-): GetSubscriptionResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | The subscription id |
-| `request` | [`UpdateSubscriptionStartAtRequest`](/doc/models/update-subscription-start-at-request.md) | Body, Required | Request for updating the subscription start date |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$request_startAt = DateTimeHelper::fromRfc3339DateTime('2016-03-13T12:52:32.123Z');
-$request = new Models\UpdateSubscriptionStartAtRequest(
-    $request_startAt
-);
-
-$result = $subscriptionsController->updateSubscriptionStartAt($subscriptionId, $request);
 ```
 
 
@@ -1648,33 +1090,6 @@ $result = $subscriptionsController->createSubscriptionItem($subscriptionId, $req
 ```
 
 
-# Get Subscription
-
-Gets a subscription
-
-```php
-function getSubscription(string $subscriptionId): GetSubscriptionResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-
-$result = $subscriptionsController->getSubscription($subscriptionId);
-```
-
-
 # Get Usages
 
 Lists all usages from a subscription item
@@ -1716,38 +1131,6 @@ $subscriptionId = 'subscription_id0';
 $itemId = 'item_id0';
 
 $result = $subscriptionsController->getUsages($subscriptionId, $itemId);
-```
-
-
-# Update Latest Period End At
-
-```php
-function updateLatestPeriodEndAt(
-    string $subscriptionId,
-    UpdateCurrentCycleEndDateRequest $request,
-    ?string $idempotencyKey = null
-): GetSubscriptionResponse
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | - |
-| `request` | [`UpdateCurrentCycleEndDateRequest`](/doc/models/update-current-cycle-end-date-request.md) | Body, Required | Request for updating the end date of the current signature cycle |
-| `idempotencyKey` | `?string` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```php
-$subscriptionId = 'subscription_id0';
-$request = new Models\UpdateCurrentCycleEndDateRequest;
-
-$result = $subscriptionsController->updateLatestPeriodEndAt($subscriptionId, $request);
 ```
 
 
@@ -1809,6 +1192,623 @@ $subscriptionId = 'subscription_id0';
 $cycleId = 'cycleId0';
 
 $result = $subscriptionsController->getSubscriptionCycleById($subscriptionId, $cycleId);
+```
+
+
+# Create an Usage
+
+Create Usage
+
+```php
+function createAnUsage(string $subscriptionId, string $itemId, ?string $idempotencyKey = null): GetUsageResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `itemId` | `string` | Template, Required | Item id |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetUsageResponse`](/doc/models/get-usage-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$itemId = 'item_id0';
+
+$result = $subscriptionsController->createAnUsage($subscriptionId, $itemId);
+```
+
+
+# Cancel Subscription
+
+Cancels a subscription
+
+```php
+function cancelSubscription(
+    string $subscriptionId,
+    ?CreateCancelSubscriptionRequest $request = null,
+    ?string $idempotencyKey = null
+): GetSubscriptionResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `request` | [`?CreateCancelSubscriptionRequest`](/doc/models/create-cancel-subscription-request.md) | Body, Optional | Request for cancelling a subscription |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$request_cancelPendingInvoices = true;
+$request = new Models\CreateCancelSubscriptionRequest(
+    $request_cancelPendingInvoices
+);
+
+$result = $subscriptionsController->cancelSubscription($subscriptionId, $request);
+```
+
+
+# Delete Subscription Item
+
+Deletes a subscription item
+
+```php
+function deleteSubscriptionItem(
+    string $subscriptionId,
+    string $subscriptionItemId,
+    ?string $idempotencyKey = null
+): GetSubscriptionItemResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `subscriptionItemId` | `string` | Template, Required | Subscription item id |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionItemResponse`](/doc/models/get-subscription-item-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$subscriptionItemId = 'subscription_item_id4';
+
+$result = $subscriptionsController->deleteSubscriptionItem($subscriptionId, $subscriptionItemId);
+```
+
+
+# Get Increments
+
+```php
+function getIncrements(string $subscriptionId, ?int $page = null, ?int $size = null): ListIncrementsResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | The subscription id |
+| `page` | `?int` | Query, Optional | Page number |
+| `size` | `?int` | Query, Optional | Page size |
+
+## Response Type
+
+[`ListIncrementsResponse`](/doc/models/list-increments-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+
+$result = $subscriptionsController->getIncrements($subscriptionId);
+```
+
+
+# Update Subscription Due Days
+
+Updates the boleto due days from a subscription
+
+```php
+function updateSubscriptionDueDays(
+    string $subscriptionId,
+    UpdateSubscriptionDueDaysRequest $request,
+    ?string $idempotencyKey = null
+): GetSubscriptionResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription Id |
+| `request` | [`UpdateSubscriptionDueDaysRequest`](/doc/models/update-subscription-due-days-request.md) | Body, Required | - |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$request_boletoDueDays = 226;
+$request = new Models\UpdateSubscriptionDueDaysRequest(
+    $request_boletoDueDays
+);
+
+$result = $subscriptionsController->updateSubscriptionDueDays($subscriptionId, $request);
+```
+
+
+# Update Subscription Card
+
+Updates the credit card from a subscription
+
+```php
+function updateSubscriptionCard(
+    string $subscriptionId,
+    UpdateSubscriptionCardRequest $request,
+    ?string $idempotencyKey = null
+): GetSubscriptionResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `request` | [`UpdateSubscriptionCardRequest`](/doc/models/update-subscription-card-request.md) | Body, Required | Request for updating a card |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$request_card_number = 'number2';
+$request_card_holderName = 'holder_name6';
+$request_card_expMonth = 80;
+$request_card_expYear = 216;
+$request_card_cvv = 'cvv8';
+$request_card_billingAddress_street = 'street2';
+$request_card_billingAddress_number = 'number0';
+$request_card_billingAddress_zipCode = 'zip_code6';
+$request_card_billingAddress_neighborhood = 'neighborhood8';
+$request_card_billingAddress_city = 'city8';
+$request_card_billingAddress_state = 'state2';
+$request_card_billingAddress_country = 'country6';
+$request_card_billingAddress_complement = 'complement2';
+$request_card_billingAddress_metadata = ['key0' => 'metadata1'];
+$request_card_billingAddress_line1 = 'line_14';
+$request_card_billingAddress_line2 = 'line_20';
+$request_card_billingAddress = new Models\CreateAddressRequest(
+    $request_card_billingAddress_street,
+    $request_card_billingAddress_number,
+    $request_card_billingAddress_zipCode,
+    $request_card_billingAddress_neighborhood,
+    $request_card_billingAddress_city,
+    $request_card_billingAddress_state,
+    $request_card_billingAddress_country,
+    $request_card_billingAddress_complement,
+    $request_card_billingAddress_metadata,
+    $request_card_billingAddress_line1,
+    $request_card_billingAddress_line2
+);
+$request_card_brand = 'brand4';
+$request_card_billingAddressId = 'billing_address_id6';
+$request_card_metadata = ['key0' => 'metadata3', 'key1' => 'metadata4', 'key2' => 'metadata5'];
+$request_card_type = 'credit';
+$request_card_options_verifyCard = false;
+$request_card_options = new Models\CreateCardOptionsRequest(
+    $request_card_options_verifyCard
+);
+$request_card_privateLabel = false;
+$request_card_label = 'label0';
+$request_card = new Models\CreateCardRequest(
+    $request_card_number,
+    $request_card_holderName,
+    $request_card_expMonth,
+    $request_card_expYear,
+    $request_card_cvv,
+    $request_card_billingAddress,
+    $request_card_brand,
+    $request_card_billingAddressId,
+    $request_card_metadata,
+    $request_card_type,
+    $request_card_options,
+    $request_card_privateLabel,
+    $request_card_label
+);
+$request_cardId = 'card_id2';
+$request = new Models\UpdateSubscriptionCardRequest(
+    $request_card,
+    $request_cardId
+);
+
+$result = $subscriptionsController->updateSubscriptionCard($subscriptionId, $request);
+```
+
+
+# Delete Usage
+
+Deletes a usage
+
+```php
+function deleteUsage(
+    string $subscriptionId,
+    string $itemId,
+    string $usageId,
+    ?string $idempotencyKey = null
+): GetUsageResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | The subscription id |
+| `itemId` | `string` | Template, Required | The subscription item id |
+| `usageId` | `string` | Template, Required | The usage id |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetUsageResponse`](/doc/models/get-usage-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$itemId = 'item_id0';
+$usageId = 'usage_id0';
+
+$result = $subscriptionsController->deleteUsage($subscriptionId, $itemId, $usageId);
+```
+
+
+# Create Discount
+
+Creates a discount
+
+```php
+function createDiscount(
+    string $subscriptionId,
+    CreateDiscountRequest $request,
+    ?string $idempotencyKey = null
+): GetDiscountResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `request` | [`CreateDiscountRequest`](/doc/models/create-discount-request.md) | Body, Required | Request for creating a discount |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetDiscountResponse`](/doc/models/get-discount-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$request_value = 185.28;
+$request_discountType = 'discount_type4';
+$request_itemId = 'item_id6';
+$request = new Models\CreateDiscountRequest(
+    $request_value,
+    $request_discountType,
+    $request_itemId
+);
+
+$result = $subscriptionsController->createDiscount($subscriptionId, $request);
+```
+
+
+# Update Subscription Payment Method
+
+Updates the payment method from a subscription
+
+```php
+function updateSubscriptionPaymentMethod(
+    string $subscriptionId,
+    UpdateSubscriptionPaymentMethodRequest $request,
+    ?string $idempotencyKey = null
+): GetSubscriptionResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `request` | [`UpdateSubscriptionPaymentMethodRequest`](/doc/models/update-subscription-payment-method-request.md) | Body, Required | Request for updating the paymentmethod from a subscription |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$request_paymentMethod = 'payment_method4';
+$request_cardId = 'card_id2';
+$request_card_number = 'number2';
+$request_card_holderName = 'holder_name6';
+$request_card_expMonth = 80;
+$request_card_expYear = 216;
+$request_card_cvv = 'cvv8';
+$request_card_billingAddress_street = 'street2';
+$request_card_billingAddress_number = 'number0';
+$request_card_billingAddress_zipCode = 'zip_code6';
+$request_card_billingAddress_neighborhood = 'neighborhood8';
+$request_card_billingAddress_city = 'city8';
+$request_card_billingAddress_state = 'state2';
+$request_card_billingAddress_country = 'country6';
+$request_card_billingAddress_complement = 'complement2';
+$request_card_billingAddress_metadata = ['key0' => 'metadata1'];
+$request_card_billingAddress_line1 = 'line_14';
+$request_card_billingAddress_line2 = 'line_20';
+$request_card_billingAddress = new Models\CreateAddressRequest(
+    $request_card_billingAddress_street,
+    $request_card_billingAddress_number,
+    $request_card_billingAddress_zipCode,
+    $request_card_billingAddress_neighborhood,
+    $request_card_billingAddress_city,
+    $request_card_billingAddress_state,
+    $request_card_billingAddress_country,
+    $request_card_billingAddress_complement,
+    $request_card_billingAddress_metadata,
+    $request_card_billingAddress_line1,
+    $request_card_billingAddress_line2
+);
+$request_card_brand = 'brand4';
+$request_card_billingAddressId = 'billing_address_id6';
+$request_card_metadata = ['key0' => 'metadata3', 'key1' => 'metadata4', 'key2' => 'metadata5'];
+$request_card_type = 'credit';
+$request_card_options_verifyCard = false;
+$request_card_options = new Models\CreateCardOptionsRequest(
+    $request_card_options_verifyCard
+);
+$request_card_privateLabel = false;
+$request_card_label = 'label0';
+$request_card = new Models\CreateCardRequest(
+    $request_card_number,
+    $request_card_holderName,
+    $request_card_expMonth,
+    $request_card_expYear,
+    $request_card_cvv,
+    $request_card_billingAddress,
+    $request_card_brand,
+    $request_card_billingAddressId,
+    $request_card_metadata,
+    $request_card_type,
+    $request_card_options,
+    $request_card_privateLabel,
+    $request_card_label
+);
+$request = new Models\UpdateSubscriptionPaymentMethodRequest(
+    $request_paymentMethod,
+    $request_cardId,
+    $request_card
+);
+
+$result = $subscriptionsController->updateSubscriptionPaymentMethod($subscriptionId, $request);
+```
+
+
+# Create Increment
+
+Creates a increment
+
+```php
+function createIncrement(
+    string $subscriptionId,
+    CreateIncrementRequest $request,
+    ?string $idempotencyKey = null
+): GetIncrementResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `request` | [`CreateIncrementRequest`](/doc/models/create-increment-request.md) | Body, Required | Request for creating a increment |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetIncrementResponse`](/doc/models/get-increment-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$request_value = 185.28;
+$request_incrementType = 'increment_type8';
+$request_itemId = 'item_id6';
+$request = new Models\CreateIncrementRequest(
+    $request_value,
+    $request_incrementType,
+    $request_itemId
+);
+
+$result = $subscriptionsController->createIncrement($subscriptionId, $request);
+```
+
+
+# Create Usage
+
+Creates a usage
+
+```php
+function createUsage(
+    string $subscriptionId,
+    string $itemId,
+    CreateUsageRequest $body,
+    ?string $idempotencyKey = null
+): GetUsageResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription Id |
+| `itemId` | `string` | Template, Required | Item id |
+| `body` | [`CreateUsageRequest`](/doc/models/create-usage-request.md) | Body, Required | Request for creating a usage |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetUsageResponse`](/doc/models/get-usage-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$itemId = 'item_id0';
+$body_quantity = 156;
+$body_description = 'description4';
+$body_usedAt = DateTimeHelper::fromRfc3339DateTime('2016-03-13T12:52:32.123Z');
+$body = new Models\CreateUsageRequest(
+    $body_quantity,
+    $body_description,
+    $body_usedAt
+);
+
+$result = $subscriptionsController->createUsage($subscriptionId, $itemId, $body);
+```
+
+
+# Get Subscription Cycles
+
+```php
+function getSubscriptionCycles(string $subscriptionId, string $page, string $size): ListCyclesResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription Id |
+| `page` | `string` | Query, Required | Page number |
+| `size` | `string` | Query, Required | Page size |
+
+## Response Type
+
+[`ListCyclesResponse`](/doc/models/list-cycles-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$page = 'page8';
+$size = 'size0';
+
+$result = $subscriptionsController->getSubscriptionCycles($subscriptionId, $page, $size);
+```
+
+
+# Update Subscription Billing Date
+
+Updates the billing date from a subscription
+
+```php
+function updateSubscriptionBillingDate(
+    string $subscriptionId,
+    UpdateSubscriptionBillingDateRequest $request,
+    ?string $idempotencyKey = null
+): GetSubscriptionResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | The subscription id |
+| `request` | [`UpdateSubscriptionBillingDateRequest`](/doc/models/update-subscription-billing-date-request.md) | Body, Required | Request for updating the subscription billing date |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$request_nextBillingAt = DateTimeHelper::fromRfc3339DateTime('2016-03-13T12:52:32.123Z');
+$request = new Models\UpdateSubscriptionBillingDateRequest(
+    $request_nextBillingAt
+);
+
+$result = $subscriptionsController->updateSubscriptionBillingDate($subscriptionId, $request);
+```
+
+
+# Update Subscription Start At
+
+Updates the start at date from a subscription
+
+```php
+function updateSubscriptionStartAt(
+    string $subscriptionId,
+    UpdateSubscriptionStartAtRequest $request,
+    ?string $idempotencyKey = null
+): GetSubscriptionResponse
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | The subscription id |
+| `request` | [`UpdateSubscriptionStartAtRequest`](/doc/models/update-subscription-start-at-request.md) | Body, Required | Request for updating the subscription start date |
+| `idempotencyKey` | `?string` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```php
+$subscriptionId = 'subscription_id0';
+$request_startAt = DateTimeHelper::fromRfc3339DateTime('2016-03-13T12:52:32.123Z');
+$request = new Models\UpdateSubscriptionStartAtRequest(
+    $request_startAt
+);
+
+$result = $subscriptionsController->updateSubscriptionStartAt($subscriptionId, $request);
 ```
 
 

--- a/doc/controllers/transfers.md
+++ b/doc/controllers/transfers.md
@@ -10,9 +10,28 @@ $transfersController = $client->getTransfersController();
 
 ## Methods
 
+* [Get Transfers](/doc/controllers/transfers.md#get-transfers)
 * [Get Transfer by Id](/doc/controllers/transfers.md#get-transfer-by-id)
 * [Create Transfer](/doc/controllers/transfers.md#create-transfer)
-* [Get Transfers](/doc/controllers/transfers.md#get-transfers)
+
+
+# Get Transfers
+
+Gets all transfers
+
+```php
+function getTransfers(): ListTransfers
+```
+
+## Response Type
+
+[`ListTransfers`](/doc/models/list-transfers.md)
+
+## Example Usage
+
+```php
+$result = $transfersController->getTransfers();
+```
 
 
 # Get Transfer by Id
@@ -69,24 +88,5 @@ $request = new Models\CreateTransfer(
 );
 
 $result = $transfersController->createTransfer($request);
-```
-
-
-# Get Transfers
-
-Gets all transfers
-
-```php
-function getTransfers(): ListTransfers
-```
-
-## Response Type
-
-[`ListTransfers`](/doc/models/list-transfers.md)
-
-## Example Usage
-
-```php
-$result = $transfersController->getTransfers();
 ```
 

--- a/doc/models/create-order-item-request.md
+++ b/doc/models/create-order-item-request.md
@@ -14,8 +14,6 @@ Request for creating an order item
 | `amount` | `int` | Required | Amount | getAmount(): int | setAmount(int amount): void |
 | `description` | `string` | Required | Description | getDescription(): string | setDescription(string description): void |
 | `quantity` | `int` | Required | Quantity | getQuantity(): int | setQuantity(int quantity): void |
-| `seller` | [`?CreateSellerRequest`](/doc/models/create-seller-request.md) | Optional | Item seller | getSeller(): ?CreateSellerRequest | setSeller(?CreateSellerRequest seller): void |
-| `sellerId` | `?string` | Optional | seller identificator | getSellerId(): ?string | setSellerId(?string sellerId): void |
 | `category` | `string` | Required | Category | getCategory(): string | setCategory(string category): void |
 | `code` | `?string` | Optional | The item code passed by the client | getCode(): ?string | setCode(?string code): void |
 
@@ -26,8 +24,6 @@ Request for creating an order item
   "amount": 46,
   "description": "description0",
   "quantity": 68,
-  "seller": null,
-  "seller_id": null,
   "category": "category2",
   "code": null
 }

--- a/doc/models/get-order-item-response.md
+++ b/doc/models/get-order-item-response.md
@@ -15,7 +15,6 @@ Response object for getting an order item
 | `amount` | `int` | Required | - | getAmount(): int | setAmount(int amount): void |
 | `description` | `string` | Required | - | getDescription(): string | setDescription(string description): void |
 | `quantity` | `int` | Required | - | getQuantity(): int | setQuantity(int quantity): void |
-| `getSellerResponse` | [`?GetSellerResponse`](/doc/models/get-seller-response.md) | Optional | Seller data | getGetSellerResponse(): ?GetSellerResponse | setGetSellerResponse(?GetSellerResponse getSellerResponse): void |
 | `category` | `string` | Required | Category | getCategory(): string | setCategory(string category): void |
 | `code` | `string` | Required | Code | getCode(): string | setCode(string code): void |
 
@@ -27,7 +26,6 @@ Response object for getting an order item
   "amount": 46,
   "description": "description0",
   "quantity": 68,
-  "GetSellerResponse": null,
   "category": "category2",
   "code": "code8"
 }

--- a/doc/models/get-order-response.md
+++ b/doc/models/get-order-response.md
@@ -43,7 +43,6 @@ Response object for getting an Order
       "amount": 13,
       "description": "description7",
       "quantity": 127,
-      "GetSellerResponse": null,
       "category": "category5",
       "code": "code5"
     },
@@ -52,7 +51,6 @@ Response object for getting an Order
       "amount": 14,
       "description": "description8",
       "quantity": 128,
-      "GetSellerResponse": null,
       "category": "category6",
       "code": "code6"
     }

--- a/doc/models/list-order-response.md
+++ b/doc/models/list-order-response.md
@@ -29,7 +29,6 @@ Response object for listing order objects
           "amount": 180,
           "description": "description2",
           "quantity": 38,
-          "GetSellerResponse": null,
           "category": "category0",
           "code": "code0"
         },
@@ -38,7 +37,6 @@ Response object for listing order objects
           "amount": 181,
           "description": "description3",
           "quantity": 39,
-          "GetSellerResponse": null,
           "category": "category1",
           "code": "code1"
         }
@@ -173,7 +171,6 @@ Response object for listing order objects
           "amount": 181,
           "description": "description3",
           "quantity": 39,
-          "GetSellerResponse": null,
           "category": "category1",
           "code": "code1"
         },
@@ -182,7 +179,6 @@ Response object for listing order objects
           "amount": 182,
           "description": "description4",
           "quantity": 40,
-          "GetSellerResponse": null,
           "category": "category2",
           "code": "code2"
         },
@@ -191,7 +187,6 @@ Response object for listing order objects
           "amount": 183,
           "description": "description5",
           "quantity": 41,
-          "GetSellerResponse": null,
           "category": "category3",
           "code": "code3"
         }

--- a/src/BasicAuthCredentials.php
+++ b/src/BasicAuthCredentials.php
@@ -18,18 +18,18 @@ interface BasicAuthCredentials
     /**
      * String value for basicAuthUserName.
      */
-    public function getBasicAuthUserName(): ?string;
+    public function getBasicAuthUserName(): string;
 
     /**
      * String value for basicAuthPassword.
      */
-    public function getBasicAuthPassword(): ?string;
+    public function getBasicAuthPassword(): string;
 
     /**
      * Checks if provided credentials match with existing ones.
      *
-     * @param string|null $basicAuthUserName The username to use with basic authentication
-     * @param string|null $basicAuthPassword The password to use with basic authentication
+     * @param string $basicAuthUserName The username to use with basic authentication
+     * @param string $basicAuthPassword The password to use with basic authentication
      */
-    public function equals(?string $basicAuthUserName, ?string $basicAuthPassword): bool;
+    public function equals(string $basicAuthUserName, string $basicAuthPassword): bool;
 }

--- a/src/BasicAuthManager.php
+++ b/src/BasicAuthManager.php
@@ -25,10 +25,10 @@ class BasicAuthManager implements AuthManagerInterface, BasicAuthCredentials
     /**
      * Returns an instance of this class.
      *
-     * @param string|null $basicAuthUserName The username to use with basic authentication
-     * @param string|null $basicAuthPassword The password to use with basic authentication
+     * @param string $basicAuthUserName The username to use with basic authentication
+     * @param string $basicAuthPassword The password to use with basic authentication
      */
-    public function __construct(?string $basicAuthUserName, ?string $basicAuthPassword)
+    public function __construct(string $basicAuthUserName, string $basicAuthPassword)
     {
         $this->basicAuthUserName = $basicAuthUserName;
         $this->basicAuthPassword = $basicAuthPassword;
@@ -37,7 +37,7 @@ class BasicAuthManager implements AuthManagerInterface, BasicAuthCredentials
     /**
      * String value for basicAuthUserName.
      */
-    public function getBasicAuthUserName(): ?string
+    public function getBasicAuthUserName(): string
     {
         return $this->basicAuthUserName;
     }
@@ -45,7 +45,7 @@ class BasicAuthManager implements AuthManagerInterface, BasicAuthCredentials
     /**
      * String value for basicAuthPassword.
      */
-    public function getBasicAuthPassword(): ?string
+    public function getBasicAuthPassword(): string
     {
         return $this->basicAuthPassword;
     }
@@ -53,10 +53,10 @@ class BasicAuthManager implements AuthManagerInterface, BasicAuthCredentials
     /**
      * Checks if provided credentials match with existing ones.
      *
-     * @param string|null $basicAuthUserName The username to use with basic authentication
-     * @param string|null $basicAuthPassword The password to use with basic authentication
+     * @param string $basicAuthUserName The username to use with basic authentication
+     * @param string $basicAuthPassword The password to use with basic authentication
      */
-    public function equals(?string $basicAuthUserName, ?string $basicAuthPassword): bool
+    public function equals(string $basicAuthUserName, string $basicAuthPassword): bool
     {
         return $basicAuthUserName == $this->basicAuthUserName &&
             $basicAuthPassword == $this->basicAuthPassword;

--- a/src/Controllers/BaseController.php
+++ b/src/Controllers/BaseController.php
@@ -50,7 +50,7 @@ class BaseController
      *
      * @var string
      */
-    protected static $userAgent = 'PagarmeCoreApi - PHP 6.1.0-alpha.0';
+    protected static $userAgent = 'PagarmeCoreApi - PHP 6.2.0';
 
     /**
      * Constructor that sets the timeout of requests
@@ -102,15 +102,15 @@ class BaseController
     {
         $mapper = new JsonMapper();
         $mapper->arChildClasses['PagarmeApiSDKLib\\Models\\GetTransactionResponse'] = [
+            'PagarmeApiSDKLib\\Models\\GetVoucherTransactionResponse',
             'PagarmeApiSDKLib\\Models\\GetBankTransferTransactionResponse',
             'PagarmeApiSDKLib\\Models\\GetSafetyPayTransactionResponse',
-            'PagarmeApiSDKLib\\Models\\GetVoucherTransactionResponse',
-            'PagarmeApiSDKLib\\Models\\GetBoletoTransactionResponse',
             'PagarmeApiSDKLib\\Models\\GetDebitCardTransactionResponse',
-            'PagarmeApiSDKLib\\Models\\GetPrivateLabelTransactionResponse',
+            'PagarmeApiSDKLib\\Models\\GetBoletoTransactionResponse',
             'PagarmeApiSDKLib\\Models\\GetCashTransactionResponse',
-            'PagarmeApiSDKLib\\Models\\GetCreditCardTransactionResponse',
-            'PagarmeApiSDKLib\\Models\\GetPixTransactionResponse'
+            'PagarmeApiSDKLib\\Models\\GetPrivateLabelTransactionResponse',
+            'PagarmeApiSDKLib\\Models\\GetPixTransactionResponse',
+            'PagarmeApiSDKLib\\Models\\GetCreditCardTransactionResponse'
         ];
         return $mapper;
     }

--- a/src/Controllers/ChargesController.php
+++ b/src/Controllers/ChargesController.php
@@ -171,6 +171,205 @@ class ChargesController extends BaseController
     }
 
     /**
+     * Updates the card from a charge
+     *
+     * @param string $chargeId Charge id
+     * @param \PagarmeApiSDKLib\Models\UpdateChargeCardRequest $request Request for updating a
+     *        charge's card
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetChargeResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function updateChargeCard(
+        string $chargeId,
+        \PagarmeApiSDKLib\Models\UpdateChargeCardRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetChargeResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/charges/{charge_id}/card';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'charge_id'       => $chargeId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetChargeResponse');
+    }
+
+    /**
+     * @param string $status
+     * @param \DateTime|null $createdSince
+     * @param \DateTime|null $createdUntil
+     *
+     * @return \PagarmeApiSDKLib\Models\GetChargesSummaryResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getChargesSummary(
+        string $status,
+        ?\DateTime $createdSince = null,
+        ?\DateTime $createdUntil = null
+    ): \PagarmeApiSDKLib\Models\GetChargesSummaryResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/charges/summary';
+
+        //process optional query parameters
+        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
+            'status'        => $status,
+            'created_since' => DateTimeHelper::toRfc3339DateTime($createdSince),
+            'created_until' => DateTimeHelper::toRfc3339DateTime($createdUntil),
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetChargesSummaryResponse');
+    }
+
+    /**
+     * Creates a new charge
+     *
+     * @param \PagarmeApiSDKLib\Models\CreateChargeRequest $request Request for creating a charge
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetChargeResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function createCharge(
+        \PagarmeApiSDKLib\Models\CreateChargeRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetChargeResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/Charges';
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetChargeResponse');
+    }
+
+    /**
      * @param string $chargeId Charge Id
      * @param int|null $page Page number
      * @param int|null $size Page size
@@ -240,24 +439,24 @@ class ChargesController extends BaseController
     }
 
     /**
-     * Updates the due date from a charge
+     * Captures a charge
      *
-     * @param string $chargeId Charge Id
-     * @param \PagarmeApiSDKLib\Models\UpdateChargeDueDateRequest $request Request for updating the
-     *        due date
+     * @param string $chargeId Charge id
+     * @param \PagarmeApiSDKLib\Models\CreateCaptureChargeRequest|null $request Request for
+     *        capturing a charge
      * @param string|null $idempotencyKey
      *
      * @return \PagarmeApiSDKLib\Models\GetChargeResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function updateChargeDueDate(
+    public function captureCharge(
         string $chargeId,
-        \PagarmeApiSDKLib\Models\UpdateChargeDueDateRequest $request,
+        ?\PagarmeApiSDKLib\Models\CreateCaptureChargeRequest $request = null,
         ?string $idempotencyKey = null
     ): \PagarmeApiSDKLib\Models\GetChargeResponse {
         //prepare query string for API call
-        $_queryBuilder = '/Charges/{charge_id}/due-date';
+        $_queryBuilder = '/charges/{charge_id}/capture';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
@@ -278,7 +477,7 @@ class ChargesController extends BaseController
         //json encode body
         $_bodyJson = Request\Body::Json($request);
 
-        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
 
         // Apply authorization to request
         $this->getAuthManager('global')->apply($_httpRequest);
@@ -290,7 +489,138 @@ class ChargesController extends BaseController
 
         // and invoke the API call request to fetch the response
         try {
-            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetChargeResponse');
+    }
+
+    /**
+     * Get a charge from its id
+     *
+     * @param string $chargeId Charge id
+     *
+     * @return \PagarmeApiSDKLib\Models\GetChargeResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getCharge(string $chargeId): \PagarmeApiSDKLib\Models\GetChargeResponse
+    {
+        //prepare query string for API call
+        $_queryBuilder = '/charges/{charge_id}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'charge_id' => $chargeId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetChargeResponse');
+    }
+
+    /**
+     * Cancel a charge
+     *
+     * @param string $chargeId Charge id
+     * @param \PagarmeApiSDKLib\Models\CreateCancelChargeRequest|null $request Request for
+     *        cancelling a charge
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetChargeResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function cancelCharge(
+        string $chargeId,
+        ?\PagarmeApiSDKLib\Models\CreateCancelChargeRequest $request = null,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetChargeResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/charges/{charge_id}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'charge_id'       => $chargeId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }
@@ -397,24 +727,22 @@ class ChargesController extends BaseController
     }
 
     /**
-     * Captures a charge
-     *
-     * @param string $chargeId Charge id
-     * @param \PagarmeApiSDKLib\Models\CreateCaptureChargeRequest|null $request Request for
-     *        capturing a charge
+     * @param string $chargeId
+     * @param \PagarmeApiSDKLib\Models\CreateConfirmPaymentRequest|null $request Request for confirm
+     *        payment
      * @param string|null $idempotencyKey
      *
      * @return \PagarmeApiSDKLib\Models\GetChargeResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function captureCharge(
+    public function confirmPayment(
         string $chargeId,
-        ?\PagarmeApiSDKLib\Models\CreateCaptureChargeRequest $request = null,
+        ?\PagarmeApiSDKLib\Models\CreateConfirmPaymentRequest $request = null,
         ?string $idempotencyKey = null
     ): \PagarmeApiSDKLib\Models\GetChargeResponse {
         //prepare query string for API call
-        $_queryBuilder = '/charges/{charge_id}/capture';
+        $_queryBuilder = '/charges/{charge_id}/confirm-payment';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
@@ -468,24 +796,24 @@ class ChargesController extends BaseController
     }
 
     /**
-     * Updates the card from a charge
+     * Updates the due date from a charge
      *
-     * @param string $chargeId Charge id
-     * @param \PagarmeApiSDKLib\Models\UpdateChargeCardRequest $request Request for updating a
-     *        charge's card
+     * @param string $chargeId Charge Id
+     * @param \PagarmeApiSDKLib\Models\UpdateChargeDueDateRequest $request Request for updating the
+     *        due date
      * @param string|null $idempotencyKey
      *
      * @return \PagarmeApiSDKLib\Models\GetChargeResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function updateChargeCard(
+    public function updateChargeDueDate(
         string $chargeId,
-        \PagarmeApiSDKLib\Models\UpdateChargeCardRequest $request,
+        \PagarmeApiSDKLib\Models\UpdateChargeDueDateRequest $request,
         ?string $idempotencyKey = null
     ): \PagarmeApiSDKLib\Models\GetChargeResponse {
         //prepare query string for API call
-        $_queryBuilder = '/charges/{charge_id}/card';
+        $_queryBuilder = '/Charges/{charge_id}/due-date';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
@@ -539,131 +867,6 @@ class ChargesController extends BaseController
     }
 
     /**
-     * Get a charge from its id
-     *
-     * @param string $chargeId Charge id
-     *
-     * @return \PagarmeApiSDKLib\Models\GetChargeResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getCharge(string $chargeId): \PagarmeApiSDKLib\Models\GetChargeResponse
-    {
-        //prepare query string for API call
-        $_queryBuilder = '/charges/{charge_id}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'charge_id' => $chargeId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetChargeResponse');
-    }
-
-    /**
-     * @param string $status
-     * @param \DateTime|null $createdSince
-     * @param \DateTime|null $createdUntil
-     *
-     * @return \PagarmeApiSDKLib\Models\GetChargesSummaryResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getChargesSummary(
-        string $status,
-        ?\DateTime $createdSince = null,
-        ?\DateTime $createdUntil = null
-    ): \PagarmeApiSDKLib\Models\GetChargesSummaryResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/charges/summary';
-
-        //process optional query parameters
-        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
-            'status'        => $status,
-            'created_since' => DateTimeHelper::toRfc3339DateTime($createdSince),
-            'created_until' => DateTimeHelper::toRfc3339DateTime($createdUntil),
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetChargesSummaryResponse');
-    }
-
-    /**
      * Retries a charge
      *
      * @param string $chargeId Charge id
@@ -708,209 +911,6 @@ class ChargesController extends BaseController
         // and invoke the API call request to fetch the response
         try {
             $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetChargeResponse');
-    }
-
-    /**
-     * Cancel a charge
-     *
-     * @param string $chargeId Charge id
-     * @param \PagarmeApiSDKLib\Models\CreateCancelChargeRequest|null $request Request for
-     *        cancelling a charge
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetChargeResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function cancelCharge(
-        string $chargeId,
-        ?\PagarmeApiSDKLib\Models\CreateCancelChargeRequest $request = null,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetChargeResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/charges/{charge_id}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'charge_id'       => $chargeId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetChargeResponse');
-    }
-
-    /**
-     * Creates a new charge
-     *
-     * @param \PagarmeApiSDKLib\Models\CreateChargeRequest $request Request for creating a charge
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetChargeResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function createCharge(
-        \PagarmeApiSDKLib\Models\CreateChargeRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetChargeResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/Charges';
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetChargeResponse');
-    }
-
-    /**
-     * @param string $chargeId
-     * @param \PagarmeApiSDKLib\Models\CreateConfirmPaymentRequest|null $request Request for confirm
-     *        payment
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetChargeResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function confirmPayment(
-        string $chargeId,
-        ?\PagarmeApiSDKLib\Models\CreateConfirmPaymentRequest $request = null,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetChargeResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/charges/{charge_id}/confirm-payment';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'charge_id'       => $chargeId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }

--- a/src/Controllers/CustomersController.php
+++ b/src/Controllers/CustomersController.php
@@ -241,70 +241,6 @@ class CustomersController extends BaseController
     }
 
     /**
-     * Creates a new customer
-     *
-     * @param \PagarmeApiSDKLib\Models\CreateCustomerRequest $request Request for creating a
-     *        customer
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetCustomerResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function createCustomer(
-        \PagarmeApiSDKLib\Models\CreateCustomerRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetCustomerResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/customers';
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetCustomerResponse');
-    }
-
-    /**
      * Creates a new address for a customer
      *
      * @param string $customerId Customer Id
@@ -375,22 +311,167 @@ class CustomersController extends BaseController
     }
 
     /**
-     * Delete a Customer's access tokens
+     * Creates a new customer
      *
-     * @param string $customerId Customer Id
+     * @param \PagarmeApiSDKLib\Models\CreateCustomerRequest $request Request for creating a
+     *        customer
+     * @param string|null $idempotencyKey
      *
-     * @return \PagarmeApiSDKLib\Models\ListAccessTokensResponse Response from the API call
+     * @return \PagarmeApiSDKLib\Models\GetCustomerResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function deleteAccessTokens(string $customerId): \PagarmeApiSDKLib\Models\ListAccessTokensResponse
-    {
+    public function createCustomer(
+        \PagarmeApiSDKLib\Models\CreateCustomerRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetCustomerResponse {
         //prepare query string for API call
-        $_queryBuilder = '/customers/{customer_id}/access-tokens/';
+        $_queryBuilder = '/customers';
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetCustomerResponse');
+    }
+
+    /**
+     * Creates a new card for a customer
+     *
+     * @param string $customerId Customer id
+     * @param \PagarmeApiSDKLib\Models\CreateCardRequest $request Request for creating a card
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetCardResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function createCard(
+        string $customerId,
+        \PagarmeApiSDKLib\Models\CreateCardRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetCardResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/customers/{customer_id}/cards';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'customer_id'     => $customerId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetCardResponse');
+    }
+
+    /**
+     * Get all cards from a customer
+     *
+     * @param string $customerId Customer Id
+     * @param int|null $page Page number
+     * @param int|null $size Page size
+     *
+     * @return \PagarmeApiSDKLib\Models\ListCardsResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getCards(
+        string $customerId,
+        ?int $page = null,
+        ?int $size = null
+    ): \PagarmeApiSDKLib\Models\ListCardsResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/customers/{customer_id}/cards';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
             'customer_id' => $customerId,
+        ]);
+
+        //process optional query parameters
+        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
+            'page'        => $page,
+            'size'        => $size,
         ]);
 
         //validate and preprocess url
@@ -431,7 +512,74 @@ class CustomersController extends BaseController
         //handle errors defined at the API level
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListAccessTokensResponse');
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListCardsResponse');
+    }
+
+    /**
+     * Renew a card
+     *
+     * @param string $customerId Customer id
+     * @param string $cardId Card Id
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetCardResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function renewCard(
+        string $customerId,
+        string $cardId,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetCardResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/customers/{customer_id}/cards/{card_id}/renew';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'customer_id'     => $customerId,
+            'card_id'         => $cardId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetCardResponse');
     }
 
     /**
@@ -564,110 +712,26 @@ class CustomersController extends BaseController
     }
 
     /**
-     * Creates a new card for a customer
+     * Get a Customer's access token
      *
-     * @param string $customerId Customer id
-     * @param \PagarmeApiSDKLib\Models\CreateCardRequest $request Request for creating a card
-     * @param string|null $idempotencyKey
+     * @param string $customerId Customer Id
+     * @param string $tokenId Token Id
      *
-     * @return \PagarmeApiSDKLib\Models\GetCardResponse Response from the API call
+     * @return \PagarmeApiSDKLib\Models\GetAccessTokenResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function createCard(
+    public function getAccessToken(
         string $customerId,
-        \PagarmeApiSDKLib\Models\CreateCardRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetCardResponse {
+        string $tokenId
+    ): \PagarmeApiSDKLib\Models\GetAccessTokenResponse {
         //prepare query string for API call
-        $_queryBuilder = '/customers/{customer_id}/cards';
+        $_queryBuilder = '/customers/{customer_id}/access-tokens/{token_id}';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'customer_id'     => $customerId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetCardResponse');
-    }
-
-    /**
-     * Get all Customers
-     *
-     * @param string|null $name Name of the Customer
-     * @param string|null $document Document of the Customer
-     * @param int|null $page Current page the the search
-     * @param int|null $size Quantity pages of the search
-     * @param string|null $email Customer's email
-     * @param string|null $code Customer's code
-     *
-     * @return \PagarmeApiSDKLib\Models\ListCustomersResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getCustomers(
-        ?string $name = null,
-        ?string $document = null,
-        ?int $page = 1,
-        ?int $size = 10,
-        ?string $email = null,
-        ?string $code = null
-    ): \PagarmeApiSDKLib\Models\ListCustomersResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/customers';
-
-        //process optional query parameters
-        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
-            'name'     => $name,
-            'document' => $document,
-            'page'     => (null != $page) ?
-                $page : 1,
-            'size'     => (null != $size) ?
-                $size : 10,
-            'email'    => $email,
-            'Code'     => $code,
+            'customer_id' => $customerId,
+            'token_id'    => $tokenId,
         ]);
 
         //validate and preprocess url
@@ -708,28 +772,28 @@ class CustomersController extends BaseController
         //handle errors defined at the API level
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListCustomersResponse');
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetAccessTokenResponse');
     }
 
     /**
-     * Updates a customer
+     * Updates the metadata a customer
      *
-     * @param string $customerId Customer id
-     * @param \PagarmeApiSDKLib\Models\UpdateCustomerRequest $request Request for updating a
-     *        customer
+     * @param string $customerId The customer id
+     * @param \PagarmeApiSDKLib\Models\UpdateMetadataRequest $request Request for updating the
+     *        customer metadata
      * @param string|null $idempotencyKey
      *
      * @return \PagarmeApiSDKLib\Models\GetCustomerResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function updateCustomer(
+    public function updateCustomerMetadata(
         string $customerId,
-        \PagarmeApiSDKLib\Models\UpdateCustomerRequest $request,
+        \PagarmeApiSDKLib\Models\UpdateMetadataRequest $request,
         ?string $idempotencyKey = null
     ): \PagarmeApiSDKLib\Models\GetCustomerResponse {
         //prepare query string for API call
-        $_queryBuilder = '/customers/{customer_id}';
+        $_queryBuilder = '/Customers/{customer_id}/metadata';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
@@ -750,7 +814,7 @@ class CustomersController extends BaseController
         //json encode body
         $_bodyJson = Request\Body::Json($request);
 
-        $_httpRequest = new HttpRequest(HttpMethod::PUT, $_headers, $_queryUrl);
+        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
 
         // Apply authorization to request
         $this->getAuthManager('global')->apply($_httpRequest);
@@ -762,7 +826,7 @@ class CustomersController extends BaseController
 
         // and invoke the API call request to fetch the response
         try {
-            $response = Request::put($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }
@@ -780,6 +844,128 @@ class CustomersController extends BaseController
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
         return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetCustomerResponse');
+    }
+
+    /**
+     * Get a customer's card
+     *
+     * @param string $customerId Customer id
+     * @param string $cardId Card id
+     *
+     * @return \PagarmeApiSDKLib\Models\GetCardResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getCard(string $customerId, string $cardId): \PagarmeApiSDKLib\Models\GetCardResponse
+    {
+        //prepare query string for API call
+        $_queryBuilder = '/customers/{customer_id}/cards/{card_id}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'customer_id' => $customerId,
+            'card_id'     => $cardId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetCardResponse');
+    }
+
+    /**
+     * Delete a Customer's access tokens
+     *
+     * @param string $customerId Customer Id
+     *
+     * @return \PagarmeApiSDKLib\Models\ListAccessTokensResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function deleteAccessTokens(string $customerId): \PagarmeApiSDKLib\Models\ListAccessTokensResponse
+    {
+        //prepare query string for API call
+        $_queryBuilder = '/customers/{customer_id}/access-tokens/';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'customer_id' => $customerId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListAccessTokensResponse');
     }
 
     /**
@@ -925,33 +1111,40 @@ class CustomersController extends BaseController
     }
 
     /**
-     * Get all cards from a customer
+     * Get all Customers
      *
-     * @param string $customerId Customer Id
-     * @param int|null $page Page number
-     * @param int|null $size Page size
+     * @param string|null $name Name of the Customer
+     * @param string|null $document Document of the Customer
+     * @param int|null $page Current page the the search
+     * @param int|null $size Quantity pages of the search
+     * @param string|null $email Customer's email
+     * @param string|null $code Customer's code
      *
-     * @return \PagarmeApiSDKLib\Models\ListCardsResponse Response from the API call
+     * @return \PagarmeApiSDKLib\Models\ListCustomersResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function getCards(
-        string $customerId,
-        ?int $page = null,
-        ?int $size = null
-    ): \PagarmeApiSDKLib\Models\ListCardsResponse {
+    public function getCustomers(
+        ?string $name = null,
+        ?string $document = null,
+        ?int $page = 1,
+        ?int $size = 10,
+        ?string $email = null,
+        ?string $code = null
+    ): \PagarmeApiSDKLib\Models\ListCustomersResponse {
         //prepare query string for API call
-        $_queryBuilder = '/customers/{customer_id}/cards';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'customer_id' => $customerId,
-        ]);
+        $_queryBuilder = '/customers';
 
         //process optional query parameters
         ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
-            'page'        => $page,
-            'size'        => $size,
+            'name'     => $name,
+            'document' => $document,
+            'page'     => (null != $page) ?
+                $page : 1,
+            'size'     => (null != $size) ?
+                $size : 10,
+            'email'    => $email,
+            'Code'     => $code,
         ]);
 
         //validate and preprocess url
@@ -992,159 +1185,28 @@ class CustomersController extends BaseController
         //handle errors defined at the API level
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListCardsResponse');
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListCustomersResponse');
     }
 
     /**
-     * Renew a card
+     * Updates a customer
      *
      * @param string $customerId Customer id
-     * @param string $cardId Card Id
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetCardResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function renewCard(
-        string $customerId,
-        string $cardId,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetCardResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/customers/{customer_id}/cards/{card_id}/renew';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'customer_id'     => $customerId,
-            'card_id'         => $cardId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetCardResponse');
-    }
-
-    /**
-     * Get a Customer's access token
-     *
-     * @param string $customerId Customer Id
-     * @param string $tokenId Token Id
-     *
-     * @return \PagarmeApiSDKLib\Models\GetAccessTokenResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getAccessToken(
-        string $customerId,
-        string $tokenId
-    ): \PagarmeApiSDKLib\Models\GetAccessTokenResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/customers/{customer_id}/access-tokens/{token_id}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'customer_id' => $customerId,
-            'token_id'    => $tokenId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetAccessTokenResponse');
-    }
-
-    /**
-     * Updates the metadata a customer
-     *
-     * @param string $customerId The customer id
-     * @param \PagarmeApiSDKLib\Models\UpdateMetadataRequest $request Request for updating the
-     *        customer metadata
+     * @param \PagarmeApiSDKLib\Models\UpdateCustomerRequest $request Request for updating a
+     *        customer
      * @param string|null $idempotencyKey
      *
      * @return \PagarmeApiSDKLib\Models\GetCustomerResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function updateCustomerMetadata(
+    public function updateCustomer(
         string $customerId,
-        \PagarmeApiSDKLib\Models\UpdateMetadataRequest $request,
+        \PagarmeApiSDKLib\Models\UpdateCustomerRequest $request,
         ?string $idempotencyKey = null
     ): \PagarmeApiSDKLib\Models\GetCustomerResponse {
         //prepare query string for API call
-        $_queryBuilder = '/Customers/{customer_id}/metadata';
+        $_queryBuilder = '/customers/{customer_id}';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
@@ -1165,7 +1227,7 @@ class CustomersController extends BaseController
         //json encode body
         $_bodyJson = Request\Body::Json($request);
 
-        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
+        $_httpRequest = new HttpRequest(HttpMethod::PUT, $_headers, $_queryUrl);
 
         // Apply authorization to request
         $this->getAuthManager('global')->apply($_httpRequest);
@@ -1177,7 +1239,7 @@ class CustomersController extends BaseController
 
         // and invoke the API call request to fetch the response
         try {
-            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+            $response = Request::put($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }
@@ -1393,67 +1455,5 @@ class CustomersController extends BaseController
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
         return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetCustomerResponse');
-    }
-
-    /**
-     * Get a customer's card
-     *
-     * @param string $customerId Customer id
-     * @param string $cardId Card id
-     *
-     * @return \PagarmeApiSDKLib\Models\GetCardResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getCard(string $customerId, string $cardId): \PagarmeApiSDKLib\Models\GetCardResponse
-    {
-        //prepare query string for API call
-        $_queryBuilder = '/customers/{customer_id}/cards/{card_id}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'customer_id' => $customerId,
-            'card_id'     => $cardId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetCardResponse');
     }
 }

--- a/src/Controllers/InvoicesController.php
+++ b/src/Controllers/InvoicesController.php
@@ -29,199 +29,6 @@ class InvoicesController extends BaseController
     }
 
     /**
-     * Updates the metadata from an invoice
-     *
-     * @param string $invoiceId The invoice id
-     * @param \PagarmeApiSDKLib\Models\UpdateMetadataRequest $request Request for updating the
-     *        invoice metadata
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetInvoiceResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function updateInvoiceMetadata(
-        string $invoiceId,
-        \PagarmeApiSDKLib\Models\UpdateMetadataRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetInvoiceResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/invoices/{invoice_id}/metadata';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'invoice_id'      => $invoiceId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetInvoiceResponse');
-    }
-
-    /**
-     * @param string $subscriptionId Subscription Id
-     *
-     * @return \PagarmeApiSDKLib\Models\GetInvoiceResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getPartialInvoice(string $subscriptionId): \PagarmeApiSDKLib\Models\GetInvoiceResponse
-    {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/partial-invoice';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetInvoiceResponse');
-    }
-
-    /**
-     * Cancels an invoice
-     *
-     * @param string $invoiceId Invoice id
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetInvoiceResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function cancelInvoice(
-        string $invoiceId,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetInvoiceResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/invoices/{invoice_id}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'invoice_id'      => $invoiceId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetInvoiceResponse');
-    }
-
-    /**
      * Create an Invoice
      *
      * @param string $subscriptionId Subscription Id
@@ -386,22 +193,155 @@ class InvoicesController extends BaseController
     }
 
     /**
-     * Gets an invoice
+     * Cancels an invoice
      *
-     * @param string $invoiceId Invoice Id
+     * @param string $invoiceId Invoice id
+     * @param string|null $idempotencyKey
      *
      * @return \PagarmeApiSDKLib\Models\GetInvoiceResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function getInvoice(string $invoiceId): \PagarmeApiSDKLib\Models\GetInvoiceResponse
-    {
+    public function cancelInvoice(
+        string $invoiceId,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetInvoiceResponse {
         //prepare query string for API call
         $_queryBuilder = '/invoices/{invoice_id}';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'invoice_id' => $invoiceId,
+            'invoice_id'      => $invoiceId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetInvoiceResponse');
+    }
+
+    /**
+     * Updates the metadata from an invoice
+     *
+     * @param string $invoiceId The invoice id
+     * @param \PagarmeApiSDKLib\Models\UpdateMetadataRequest $request Request for updating the
+     *        invoice metadata
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetInvoiceResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function updateInvoiceMetadata(
+        string $invoiceId,
+        \PagarmeApiSDKLib\Models\UpdateMetadataRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetInvoiceResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/invoices/{invoice_id}/metadata';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'invoice_id'      => $invoiceId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetInvoiceResponse');
+    }
+
+    /**
+     * @param string $subscriptionId Subscription Id
+     *
+     * @return \PagarmeApiSDKLib\Models\GetInvoiceResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getPartialInvoice(string $subscriptionId): \PagarmeApiSDKLib\Models\GetInvoiceResponse
+    {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/partial-invoice';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
         ]);
 
         //validate and preprocess url
@@ -497,6 +437,66 @@ class InvoicesController extends BaseController
         // and invoke the API call request to fetch the response
         try {
             $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetInvoiceResponse');
+    }
+
+    /**
+     * Gets an invoice
+     *
+     * @param string $invoiceId Invoice Id
+     *
+     * @return \PagarmeApiSDKLib\Models\GetInvoiceResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getInvoice(string $invoiceId): \PagarmeApiSDKLib\Models\GetInvoiceResponse
+    {
+        //prepare query string for API call
+        $_queryBuilder = '/invoices/{invoice_id}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'invoice_id' => $invoiceId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }

--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -110,26 +110,20 @@ class OrdersController extends BaseController
     /**
      * @param string $orderId Order Id
      * @param string $itemId Item Id
-     * @param \PagarmeApiSDKLib\Models\UpdateOrderItemRequest $request Item Model
-     * @param string|null $idempotencyKey
      *
      * @return \PagarmeApiSDKLib\Models\GetOrderItemResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function updateOrderItem(
-        string $orderId,
-        string $itemId,
-        \PagarmeApiSDKLib\Models\UpdateOrderItemRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetOrderItemResponse {
+    public function getOrderItem(string $orderId, string $itemId): \PagarmeApiSDKLib\Models\GetOrderItemResponse
+    {
         //prepare query string for API call
         $_queryBuilder = '/orders/{orderId}/items/{itemId}';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'orderId'         => $orderId,
-            'itemId'          => $itemId,
+            'orderId' => $orderId,
+            'itemId'  => $itemId,
         ]);
 
         //validate and preprocess url
@@ -138,15 +132,10 @@ class OrdersController extends BaseController
         //prepare headers
         $_headers = [
             'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
+            'Accept'        => 'application/json'
         ];
 
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::PUT, $_headers, $_queryUrl);
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
 
         // Apply authorization to request
         $this->getAuthManager('global')->apply($_httpRequest);
@@ -158,7 +147,7 @@ class OrdersController extends BaseController
 
         // and invoke the API call request to fetch the response
         try {
-            $response = Request::put($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }
@@ -179,23 +168,22 @@ class OrdersController extends BaseController
     }
 
     /**
-     * @param string $orderId Order Id
-     * @param string|null $idempotencyKey
+     * Gets an order
+     *
+     * @param string $orderId Order id
      *
      * @return \PagarmeApiSDKLib\Models\GetOrderResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function deleteAllOrderItems(
-        string $orderId,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetOrderResponse {
+    public function getOrder(string $orderId): \PagarmeApiSDKLib\Models\GetOrderResponse
+    {
         //prepare query string for API call
-        $_queryBuilder = '/orders/{orderId}/items';
+        $_queryBuilder = '/orders/{order_id}';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'orderId'         => $orderId,
+            'order_id' => $orderId,
         ]);
 
         //validate and preprocess url
@@ -204,11 +192,10 @@ class OrdersController extends BaseController
         //prepare headers
         $_headers = [
             'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'idempotency-key' => $idempotencyKey
+            'Accept'        => 'application/json'
         ];
 
-        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
 
         // Apply authorization to request
         $this->getAuthManager('global')->apply($_httpRequest);
@@ -220,7 +207,7 @@ class OrdersController extends BaseController
 
         // and invoke the API call request to fetch the response
         try {
-            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }
@@ -238,71 +225,6 @@ class OrdersController extends BaseController
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
         return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetOrderResponse');
-    }
-
-    /**
-     * @param string $orderId Order Id
-     * @param string $itemId Item Id
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetOrderItemResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function deleteOrderItem(
-        string $orderId,
-        string $itemId,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetOrderItemResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/orders/{orderId}/items/{itemId}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'orderId'         => $orderId,
-            'itemId'          => $itemId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetOrderItemResponse');
     }
 
     /**
@@ -438,24 +360,27 @@ class OrdersController extends BaseController
 
     /**
      * @param string $orderId Order Id
-     * @param \PagarmeApiSDKLib\Models\CreateOrderItemRequest $request Order Item Model
+     * @param string $itemId Item Id
+     * @param \PagarmeApiSDKLib\Models\UpdateOrderItemRequest $request Item Model
      * @param string|null $idempotencyKey
      *
      * @return \PagarmeApiSDKLib\Models\GetOrderItemResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function createOrderItem(
+    public function updateOrderItem(
         string $orderId,
-        \PagarmeApiSDKLib\Models\CreateOrderItemRequest $request,
+        string $itemId,
+        \PagarmeApiSDKLib\Models\UpdateOrderItemRequest $request,
         ?string $idempotencyKey = null
     ): \PagarmeApiSDKLib\Models\GetOrderItemResponse {
         //prepare query string for API call
-        $_queryBuilder = '/orders/{orderId}/items';
+        $_queryBuilder = '/orders/{orderId}/items/{itemId}';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
             'orderId'         => $orderId,
+            'itemId'          => $itemId,
         ]);
 
         //validate and preprocess url
@@ -472,7 +397,7 @@ class OrdersController extends BaseController
         //json encode body
         $_bodyJson = Request\Body::Json($request);
 
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
+        $_httpRequest = new HttpRequest(HttpMethod::PUT, $_headers, $_queryUrl);
 
         // Apply authorization to request
         $this->getAuthManager('global')->apply($_httpRequest);
@@ -484,7 +409,7 @@ class OrdersController extends BaseController
 
         // and invoke the API call request to fetch the response
         try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+            $response = Request::put($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }
@@ -506,21 +431,22 @@ class OrdersController extends BaseController
 
     /**
      * @param string $orderId Order Id
-     * @param string $itemId Item Id
+     * @param string|null $idempotencyKey
      *
-     * @return \PagarmeApiSDKLib\Models\GetOrderItemResponse Response from the API call
+     * @return \PagarmeApiSDKLib\Models\GetOrderResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function getOrderItem(string $orderId, string $itemId): \PagarmeApiSDKLib\Models\GetOrderItemResponse
-    {
+    public function deleteAllOrderItems(
+        string $orderId,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetOrderResponse {
         //prepare query string for API call
-        $_queryBuilder = '/orders/{orderId}/items/{itemId}';
+        $_queryBuilder = '/orders/{orderId}/items';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'orderId' => $orderId,
-            'itemId'  => $itemId,
+            'orderId'         => $orderId,
         ]);
 
         //validate and preprocess url
@@ -529,10 +455,11 @@ class OrdersController extends BaseController
         //prepare headers
         $_headers = [
             'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
+            'Accept'        => 'application/json',
+            'idempotency-key' => $idempotencyKey
         ];
 
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
 
         // Apply authorization to request
         $this->getAuthManager('global')->apply($_httpRequest);
@@ -544,7 +471,7 @@ class OrdersController extends BaseController
 
         // and invoke the API call request to fetch the response
         try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }
@@ -561,7 +488,7 @@ class OrdersController extends BaseController
         //handle errors defined at the API level
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetOrderItemResponse');
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetOrderResponse');
     }
 
     /**
@@ -636,22 +563,26 @@ class OrdersController extends BaseController
     }
 
     /**
-     * Gets an order
+     * @param string $orderId Order Id
+     * @param string $itemId Item Id
+     * @param string|null $idempotencyKey
      *
-     * @param string $orderId Order id
-     *
-     * @return \PagarmeApiSDKLib\Models\GetOrderResponse Response from the API call
+     * @return \PagarmeApiSDKLib\Models\GetOrderItemResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function getOrder(string $orderId): \PagarmeApiSDKLib\Models\GetOrderResponse
-    {
+    public function deleteOrderItem(
+        string $orderId,
+        string $itemId,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetOrderItemResponse {
         //prepare query string for API call
-        $_queryBuilder = '/orders/{order_id}';
+        $_queryBuilder = '/orders/{orderId}/items/{itemId}';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'order_id' => $orderId,
+            'orderId'         => $orderId,
+            'itemId'          => $itemId,
         ]);
 
         //validate and preprocess url
@@ -660,10 +591,11 @@ class OrdersController extends BaseController
         //prepare headers
         $_headers = [
             'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
+            'Accept'        => 'application/json',
+            'idempotency-key' => $idempotencyKey
         ];
 
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
 
         // Apply authorization to request
         $this->getAuthManager('global')->apply($_httpRequest);
@@ -675,7 +607,7 @@ class OrdersController extends BaseController
 
         // and invoke the API call request to fetch the response
         try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }
@@ -692,6 +624,74 @@ class OrdersController extends BaseController
         //handle errors defined at the API level
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetOrderResponse');
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetOrderItemResponse');
+    }
+
+    /**
+     * @param string $orderId Order Id
+     * @param \PagarmeApiSDKLib\Models\CreateOrderItemRequest $request Order Item Model
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetOrderItemResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function createOrderItem(
+        string $orderId,
+        \PagarmeApiSDKLib\Models\CreateOrderItemRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetOrderItemResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/orders/{orderId}/items';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'orderId'         => $orderId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetOrderItemResponse');
     }
 }

--- a/src/Controllers/PlansController.php
+++ b/src/Controllers/PlansController.php
@@ -89,17 +89,19 @@ class PlansController extends BaseController
     }
 
     /**
-     * Deletes a plan
+     * Updates a plan
      *
      * @param string $planId Plan id
+     * @param \PagarmeApiSDKLib\Models\UpdatePlanRequest $request Request for updating a plan
      * @param string|null $idempotencyKey
      *
      * @return \PagarmeApiSDKLib\Models\GetPlanResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function deletePlan(
+    public function updatePlan(
         string $planId,
+        \PagarmeApiSDKLib\Models\UpdatePlanRequest $request,
         ?string $idempotencyKey = null
     ): \PagarmeApiSDKLib\Models\GetPlanResponse {
         //prepare query string for API call
@@ -117,10 +119,14 @@ class PlansController extends BaseController
         $_headers = [
             'user-agent'    => self::$userAgent,
             'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
             'idempotency-key' => $idempotencyKey
         ];
 
-        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::PUT, $_headers, $_queryUrl);
 
         // Apply authorization to request
         $this->getAuthManager('global')->apply($_httpRequest);
@@ -132,7 +138,7 @@ class PlansController extends BaseController
 
         // and invoke the API call request to fetch the response
         try {
-            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+            $response = Request::put($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }
@@ -204,276 +210,6 @@ class PlansController extends BaseController
         // and invoke the API call request to fetch the response
         try {
             $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetPlanResponse');
-    }
-
-    /**
-     * Updates a plan item
-     *
-     * @param string $planId Plan id
-     * @param string $planItemId Plan item id
-     * @param \PagarmeApiSDKLib\Models\UpdatePlanItemRequest $body Request for updating the plan
-     *        item
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetPlanItemResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function updatePlanItem(
-        string $planId,
-        string $planItemId,
-        \PagarmeApiSDKLib\Models\UpdatePlanItemRequest $body,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetPlanItemResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/plans/{plan_id}/items/{plan_item_id}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'plan_id'         => $planId,
-            'plan_item_id'    => $planItemId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($body);
-
-        $_httpRequest = new HttpRequest(HttpMethod::PUT, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::put($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetPlanItemResponse');
-    }
-
-    /**
-     * Adds a new item to a plan
-     *
-     * @param string $planId Plan id
-     * @param \PagarmeApiSDKLib\Models\CreatePlanItemRequest $request Request for creating a plan
-     *        item
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetPlanItemResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function createPlanItem(
-        string $planId,
-        \PagarmeApiSDKLib\Models\CreatePlanItemRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetPlanItemResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/plans/{plan_id}/items';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'plan_id'         => $planId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetPlanItemResponse');
-    }
-
-    /**
-     * Gets a plan item
-     *
-     * @param string $planId Plan id
-     * @param string $planItemId Plan item id
-     *
-     * @return \PagarmeApiSDKLib\Models\GetPlanItemResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getPlanItem(string $planId, string $planItemId): \PagarmeApiSDKLib\Models\GetPlanItemResponse
-    {
-        //prepare query string for API call
-        $_queryBuilder = '/plans/{plan_id}/items/{plan_item_id}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'plan_id'      => $planId,
-            'plan_item_id' => $planItemId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetPlanItemResponse');
-    }
-
-    /**
-     * Creates a new plan
-     *
-     * @param \PagarmeApiSDKLib\Models\CreatePlanRequest $body Request for creating a plan
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetPlanResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function createPlan(
-        \PagarmeApiSDKLib\Models\CreatePlanRequest $body,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetPlanResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/plans';
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($body);
-
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }
@@ -640,23 +376,224 @@ class PlansController extends BaseController
     }
 
     /**
-     * Updates a plan
+     * Gets a plan item
      *
      * @param string $planId Plan id
-     * @param \PagarmeApiSDKLib\Models\UpdatePlanRequest $request Request for updating a plan
+     * @param string $planItemId Plan item id
+     *
+     * @return \PagarmeApiSDKLib\Models\GetPlanItemResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getPlanItem(string $planId, string $planItemId): \PagarmeApiSDKLib\Models\GetPlanItemResponse
+    {
+        //prepare query string for API call
+        $_queryBuilder = '/plans/{plan_id}/items/{plan_item_id}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'plan_id'      => $planId,
+            'plan_item_id' => $planItemId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetPlanItemResponse');
+    }
+
+    /**
+     * Deletes a plan
+     *
+     * @param string $planId Plan id
      * @param string|null $idempotencyKey
      *
      * @return \PagarmeApiSDKLib\Models\GetPlanResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function updatePlan(
+    public function deletePlan(
         string $planId,
-        \PagarmeApiSDKLib\Models\UpdatePlanRequest $request,
         ?string $idempotencyKey = null
     ): \PagarmeApiSDKLib\Models\GetPlanResponse {
         //prepare query string for API call
         $_queryBuilder = '/plans/{plan_id}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'plan_id'         => $planId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetPlanResponse');
+    }
+
+    /**
+     * Updates a plan item
+     *
+     * @param string $planId Plan id
+     * @param string $planItemId Plan item id
+     * @param \PagarmeApiSDKLib\Models\UpdatePlanItemRequest $body Request for updating the plan
+     *        item
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetPlanItemResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function updatePlanItem(
+        string $planId,
+        string $planItemId,
+        \PagarmeApiSDKLib\Models\UpdatePlanItemRequest $body,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetPlanItemResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/plans/{plan_id}/items/{plan_item_id}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'plan_id'         => $planId,
+            'plan_item_id'    => $planItemId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($body);
+
+        $_httpRequest = new HttpRequest(HttpMethod::PUT, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::put($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetPlanItemResponse');
+    }
+
+    /**
+     * Adds a new item to a plan
+     *
+     * @param string $planId Plan id
+     * @param \PagarmeApiSDKLib\Models\CreatePlanItemRequest $request Request for creating a plan
+     *        item
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetPlanItemResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function createPlanItem(
+        string $planId,
+        \PagarmeApiSDKLib\Models\CreatePlanItemRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetPlanItemResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/plans/{plan_id}/items';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
@@ -677,7 +614,7 @@ class PlansController extends BaseController
         //json encode body
         $_bodyJson = Request\Body::Json($request);
 
-        $_httpRequest = new HttpRequest(HttpMethod::PUT, $_headers, $_queryUrl);
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
 
         // Apply authorization to request
         $this->getAuthManager('global')->apply($_httpRequest);
@@ -689,7 +626,70 @@ class PlansController extends BaseController
 
         // and invoke the API call request to fetch the response
         try {
-            $response = Request::put($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetPlanItemResponse');
+    }
+
+    /**
+     * Creates a new plan
+     *
+     * @param \PagarmeApiSDKLib\Models\CreatePlanRequest $body Request for creating a plan
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetPlanResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function createPlan(
+        \PagarmeApiSDKLib\Models\CreatePlanRequest $body,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetPlanResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/plans';
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($body);
+
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }

--- a/src/Controllers/RecipientsController.php
+++ b/src/Controllers/RecipientsController.php
@@ -302,138 +302,6 @@ class RecipientsController extends BaseController
     }
 
     /**
-     * @param string $recipientId
-     * @param string $withdrawalId
-     *
-     * @return \PagarmeApiSDKLib\Models\GetWithdrawResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getWithdrawById(
-        string $recipientId,
-        string $withdrawalId
-    ): \PagarmeApiSDKLib\Models\GetWithdrawResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/recipients/{recipient_id}/withdrawals/{withdrawal_id}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'recipient_id'  => $recipientId,
-            'withdrawal_id' => $withdrawalId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetWithdrawResponse');
-    }
-
-    /**
-     * Updates the default bank account from a recipient
-     *
-     * @param string $recipientId Recipient id
-     * @param \PagarmeApiSDKLib\Models\UpdateRecipientBankAccountRequest $request Bank account data
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetRecipientResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function updateRecipientDefaultBankAccount(
-        string $recipientId,
-        \PagarmeApiSDKLib\Models\UpdateRecipientBankAccountRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetRecipientResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/recipients/{recipient_id}/default-bank-account';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'recipient_id'    => $recipientId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetRecipientResponse');
-    }
-
-    /**
      * Updates recipient metadata
      *
      * @param string $recipientId Recipient id
@@ -504,86 +372,6 @@ class RecipientsController extends BaseController
     }
 
     /**
-     * Gets a paginated list of transfers for the recipient
-     *
-     * @param string $recipientId Recipient id
-     * @param int|null $page Page number
-     * @param int|null $size Page size
-     * @param string|null $status Filter for transfer status
-     * @param \DateTime|null $createdSince Filter for start range of transfer creation date
-     * @param \DateTime|null $createdUntil Filter for end range of transfer creation date
-     *
-     * @return \PagarmeApiSDKLib\Models\ListTransferResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getTransfers(
-        string $recipientId,
-        ?int $page = null,
-        ?int $size = null,
-        ?string $status = null,
-        ?\DateTime $createdSince = null,
-        ?\DateTime $createdUntil = null
-    ): \PagarmeApiSDKLib\Models\ListTransferResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/recipients/{recipient_id}/transfers';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'recipient_id'  => $recipientId,
-        ]);
-
-        //process optional query parameters
-        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
-            'page'          => $page,
-            'size'          => $size,
-            'status'        => $status,
-            'created_since' => DateTimeHelper::toRfc3339DateTime($createdSince),
-            'created_until' => DateTimeHelper::toRfc3339DateTime($createdUntil),
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListTransferResponse');
-    }
-
-    /**
      * Gets a transfer
      *
      * @param string $recipientId Recipient id
@@ -643,141 +431,6 @@ class RecipientsController extends BaseController
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
         return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetTransferResponse');
-    }
-
-    /**
-     * @param string $recipientId
-     * @param \PagarmeApiSDKLib\Models\CreateWithdrawRequest $request
-     *
-     * @return \PagarmeApiSDKLib\Models\GetWithdrawResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function createWithdraw(
-        string $recipientId,
-        \PagarmeApiSDKLib\Models\CreateWithdrawRequest $request
-    ): \PagarmeApiSDKLib\Models\GetWithdrawResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/recipients/{recipient_id}/withdrawals';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'recipient_id' => $recipientId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json'
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetWithdrawResponse');
-    }
-
-    /**
-     * Updates recipient metadata
-     *
-     * @param string $recipientId Recipient id
-     * @param \PagarmeApiSDKLib\Models\UpdateAutomaticAnticipationSettingsRequest $request Metadata
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetRecipientResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function updateAutomaticAnticipationSettings(
-        string $recipientId,
-        \PagarmeApiSDKLib\Models\UpdateAutomaticAnticipationSettingsRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetRecipientResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/recipients/{recipient_id}/automatic-anticipation-settings';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'recipient_id'    => $recipientId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetRecipientResponse');
     }
 
     /**
@@ -1002,22 +655,27 @@ class RecipientsController extends BaseController
     }
 
     /**
-     * Retrieves recipient information
+     * Updates the default bank account from a recipient
      *
-     * @param string $recipientId Recipiend id
+     * @param string $recipientId Recipient id
+     * @param \PagarmeApiSDKLib\Models\UpdateRecipientBankAccountRequest $request Bank account data
+     * @param string|null $idempotencyKey
      *
      * @return \PagarmeApiSDKLib\Models\GetRecipientResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function getRecipient(string $recipientId): \PagarmeApiSDKLib\Models\GetRecipientResponse
-    {
+    public function updateRecipientDefaultBankAccount(
+        string $recipientId,
+        \PagarmeApiSDKLib\Models\UpdateRecipientBankAccountRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetRecipientResponse {
         //prepare query string for API call
-        $_queryBuilder = '/recipients/{recipient_id}';
+        $_queryBuilder = '/recipients/{recipient_id}/default-bank-account';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'recipient_id' => $recipientId,
+            'recipient_id'    => $recipientId,
         ]);
 
         //validate and preprocess url
@@ -1026,10 +684,15 @@ class RecipientsController extends BaseController
         //prepare headers
         $_headers = [
             'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
         ];
 
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
 
         // Apply authorization to request
         $this->getAuthManager('global')->apply($_httpRequest);
@@ -1041,7 +704,7 @@ class RecipientsController extends BaseController
 
         // and invoke the API call request to fetch the response
         try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }
@@ -1059,6 +722,71 @@ class RecipientsController extends BaseController
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
         return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetRecipientResponse');
+    }
+
+    /**
+     * @param string $recipientId
+     * @param \PagarmeApiSDKLib\Models\CreateWithdrawRequest $request
+     *
+     * @return \PagarmeApiSDKLib\Models\GetWithdrawResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function createWithdraw(
+        string $recipientId,
+        \PagarmeApiSDKLib\Models\CreateWithdrawRequest $request
+    ): \PagarmeApiSDKLib\Models\GetWithdrawResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/recipients/{recipient_id}/withdrawals';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'recipient_id' => $recipientId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json'
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetWithdrawResponse');
     }
 
     /**
@@ -1119,86 +847,6 @@ class RecipientsController extends BaseController
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
         return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetBalanceResponse');
-    }
-
-    /**
-     * Gets a paginated list of transfers for the recipient
-     *
-     * @param string $recipientId
-     * @param int|null $page
-     * @param int|null $size
-     * @param string|null $status
-     * @param \DateTime|null $createdSince
-     * @param \DateTime|null $createdUntil
-     *
-     * @return \PagarmeApiSDKLib\Models\ListWithdrawals Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getWithdrawals(
-        string $recipientId,
-        ?int $page = null,
-        ?int $size = null,
-        ?string $status = null,
-        ?\DateTime $createdSince = null,
-        ?\DateTime $createdUntil = null
-    ): \PagarmeApiSDKLib\Models\ListWithdrawals {
-        //prepare query string for API call
-        $_queryBuilder = '/recipients/{recipient_id}/withdrawals';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'recipient_id'  => $recipientId,
-        ]);
-
-        //process optional query parameters
-        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
-            'page'          => $page,
-            'size'          => $size,
-            'status'        => $status,
-            'created_since' => DateTimeHelper::toRfc3339DateTime($createdSince),
-            'created_until' => DateTimeHelper::toRfc3339DateTime($createdUntil),
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListWithdrawals');
     }
 
     /**
@@ -1332,6 +980,358 @@ class RecipientsController extends BaseController
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
         return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetRecipientResponse');
+    }
+
+    /**
+     * Updates recipient metadata
+     *
+     * @param string $recipientId Recipient id
+     * @param \PagarmeApiSDKLib\Models\UpdateAutomaticAnticipationSettingsRequest $request Metadata
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetRecipientResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function updateAutomaticAnticipationSettings(
+        string $recipientId,
+        \PagarmeApiSDKLib\Models\UpdateAutomaticAnticipationSettingsRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetRecipientResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/recipients/{recipient_id}/automatic-anticipation-settings';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'recipient_id'    => $recipientId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetRecipientResponse');
+    }
+
+    /**
+     * Retrieves recipient information
+     *
+     * @param string $recipientId Recipiend id
+     *
+     * @return \PagarmeApiSDKLib\Models\GetRecipientResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getRecipient(string $recipientId): \PagarmeApiSDKLib\Models\GetRecipientResponse
+    {
+        //prepare query string for API call
+        $_queryBuilder = '/recipients/{recipient_id}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'recipient_id' => $recipientId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetRecipientResponse');
+    }
+
+    /**
+     * Gets a paginated list of transfers for the recipient
+     *
+     * @param string $recipientId
+     * @param int|null $page
+     * @param int|null $size
+     * @param string|null $status
+     * @param \DateTime|null $createdSince
+     * @param \DateTime|null $createdUntil
+     *
+     * @return \PagarmeApiSDKLib\Models\ListWithdrawals Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getWithdrawals(
+        string $recipientId,
+        ?int $page = null,
+        ?int $size = null,
+        ?string $status = null,
+        ?\DateTime $createdSince = null,
+        ?\DateTime $createdUntil = null
+    ): \PagarmeApiSDKLib\Models\ListWithdrawals {
+        //prepare query string for API call
+        $_queryBuilder = '/recipients/{recipient_id}/withdrawals';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'recipient_id'  => $recipientId,
+        ]);
+
+        //process optional query parameters
+        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
+            'page'          => $page,
+            'size'          => $size,
+            'status'        => $status,
+            'created_since' => DateTimeHelper::toRfc3339DateTime($createdSince),
+            'created_until' => DateTimeHelper::toRfc3339DateTime($createdUntil),
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListWithdrawals');
+    }
+
+    /**
+     * @param string $recipientId
+     * @param string $withdrawalId
+     *
+     * @return \PagarmeApiSDKLib\Models\GetWithdrawResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getWithdrawById(
+        string $recipientId,
+        string $withdrawalId
+    ): \PagarmeApiSDKLib\Models\GetWithdrawResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/recipients/{recipient_id}/withdrawals/{withdrawal_id}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'recipient_id'  => $recipientId,
+            'withdrawal_id' => $withdrawalId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetWithdrawResponse');
+    }
+
+    /**
+     * Gets a paginated list of transfers for the recipient
+     *
+     * @param string $recipientId Recipient id
+     * @param int|null $page Page number
+     * @param int|null $size Page size
+     * @param string|null $status Filter for transfer status
+     * @param \DateTime|null $createdSince Filter for start range of transfer creation date
+     * @param \DateTime|null $createdUntil Filter for end range of transfer creation date
+     *
+     * @return \PagarmeApiSDKLib\Models\ListTransferResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getTransfers(
+        string $recipientId,
+        ?int $page = null,
+        ?int $size = null,
+        ?string $status = null,
+        ?\DateTime $createdSince = null,
+        ?\DateTime $createdUntil = null
+    ): \PagarmeApiSDKLib\Models\ListTransferResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/recipients/{recipient_id}/transfers';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'recipient_id'  => $recipientId,
+        ]);
+
+        //process optional query parameters
+        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
+            'page'          => $page,
+            'size'          => $size,
+            'status'        => $status,
+            'created_since' => DateTimeHelper::toRfc3339DateTime($createdSince),
+            'created_until' => DateTimeHelper::toRfc3339DateTime($createdUntil),
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListTransferResponse');
     }
 
     /**

--- a/src/Controllers/SubscriptionsController.php
+++ b/src/Controllers/SubscriptionsController.php
@@ -91,351 +91,6 @@ class SubscriptionsController extends BaseController
     }
 
     /**
-     * Updates the credit card from a subscription
-     *
-     * @param string $subscriptionId Subscription id
-     * @param \PagarmeApiSDKLib\Models\UpdateSubscriptionCardRequest $request Request for updating a
-     *        card
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function updateSubscriptionCard(
-        string $subscriptionId,
-        \PagarmeApiSDKLib\Models\UpdateSubscriptionCardRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetSubscriptionResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/card';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
-    }
-
-    /**
-     * Deletes a usage
-     *
-     * @param string $subscriptionId The subscription id
-     * @param string $itemId The subscription item id
-     * @param string $usageId The usage id
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetUsageResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function deleteUsage(
-        string $subscriptionId,
-        string $itemId,
-        string $usageId,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetUsageResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/items/{item_id}/usages/{usage_id}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-            'item_id'         => $itemId,
-            'usage_id'        => $usageId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetUsageResponse');
-    }
-
-    /**
-     * Creates a discount
-     *
-     * @param string $subscriptionId Subscription id
-     * @param \PagarmeApiSDKLib\Models\CreateDiscountRequest $request Request for creating a
-     *        discount
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetDiscountResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function createDiscount(
-        string $subscriptionId,
-        \PagarmeApiSDKLib\Models\CreateDiscountRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetDiscountResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/discounts';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetDiscountResponse');
-    }
-
-    /**
-     * Create Usage
-     *
-     * @param string $subscriptionId Subscription id
-     * @param string $itemId Item id
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetUsageResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function createAnUsage(
-        string $subscriptionId,
-        string $itemId,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetUsageResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/items/{item_id}/usages';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-            'item_id'         => $itemId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetUsageResponse');
-    }
-
-    /**
-     * @param string $subscriptionId Subscription Id
-     * @param \PagarmeApiSDKLib\Models\UpdateCurrentCycleStatusRequest $request Request for updating
-     *        the end date of the subscription current status
-     * @param string|null $idempotencyKey
-     *
-     * @return void Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function updateCurrentCycleStatus(
-        string $subscriptionId,
-        \PagarmeApiSDKLib\Models\UpdateCurrentCycleStatusRequest $request,
-        ?string $idempotencyKey = null
-    ): void {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/cycle-status';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-    }
-
-    /**
      * Deletes a discount
      *
      * @param string $subscriptionId Subscription id
@@ -500,230 +155,6 @@ class SubscriptionsController extends BaseController
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
         return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetDiscountResponse');
-    }
-
-    /**
-     * Get Subscription Items
-     *
-     * @param string $subscriptionId The subscription id
-     * @param int|null $page Page number
-     * @param int|null $size Page size
-     * @param string|null $name The item name
-     * @param string|null $code Identification code in the client system
-     * @param string|null $status The item statis
-     * @param string|null $description The item description
-     * @param string|null $createdSince Filter for item's creation date start range
-     * @param string|null $createdUntil Filter for item's creation date end range
-     *
-     * @return \PagarmeApiSDKLib\Models\ListSubscriptionItemsResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getSubscriptionItems(
-        string $subscriptionId,
-        ?int $page = null,
-        ?int $size = null,
-        ?string $name = null,
-        ?string $code = null,
-        ?string $status = null,
-        ?string $description = null,
-        ?string $createdSince = null,
-        ?string $createdUntil = null
-    ): \PagarmeApiSDKLib\Models\ListSubscriptionItemsResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/items';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-        ]);
-
-        //process optional query parameters
-        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
-            'page'            => $page,
-            'size'            => $size,
-            'name'            => $name,
-            'code'            => $code,
-            'status'          => $status,
-            'description'     => $description,
-            'created_since'   => $createdSince,
-            'created_until'   => $createdUntil,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListSubscriptionItemsResponse');
-    }
-
-    /**
-     * Updates the payment method from a subscription
-     *
-     * @param string $subscriptionId Subscription id
-     * @param \PagarmeApiSDKLib\Models\UpdateSubscriptionPaymentMethodRequest $request Request for
-     *        updating the paymentmethod from a subscription
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function updateSubscriptionPaymentMethod(
-        string $subscriptionId,
-        \PagarmeApiSDKLib\Models\UpdateSubscriptionPaymentMethodRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetSubscriptionResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/payment-method';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
-    }
-
-    /**
-     * Get Subscription Item
-     *
-     * @param string $subscriptionId Subscription Id
-     * @param string $itemId Item id
-     *
-     * @return \PagarmeApiSDKLib\Models\GetSubscriptionItemResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getSubscriptionItem(
-        string $subscriptionId,
-        string $itemId
-    ): \PagarmeApiSDKLib\Models\GetSubscriptionItemResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/items/{item_id}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-            'item_id'         => $itemId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionItemResponse');
     }
 
     /**
@@ -819,221 +250,6 @@ class SubscriptionsController extends BaseController
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
         return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListSubscriptionsResponse');
-    }
-
-    /**
-     * Cancels a subscription
-     *
-     * @param string $subscriptionId Subscription id
-     * @param \PagarmeApiSDKLib\Models\CreateCancelSubscriptionRequest|null $request Request for
-     *        cancelling a subscription
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function cancelSubscription(
-        string $subscriptionId,
-        ?\PagarmeApiSDKLib\Models\CreateCancelSubscriptionRequest $request = null,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetSubscriptionResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
-    }
-
-    /**
-     * Creates a increment
-     *
-     * @param string $subscriptionId Subscription id
-     * @param \PagarmeApiSDKLib\Models\CreateIncrementRequest $request Request for creating a
-     *        increment
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetIncrementResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function createIncrement(
-        string $subscriptionId,
-        \PagarmeApiSDKLib\Models\CreateIncrementRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetIncrementResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/increments';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetIncrementResponse');
-    }
-
-    /**
-     * Creates a usage
-     *
-     * @param string $subscriptionId Subscription Id
-     * @param string $itemId Item id
-     * @param \PagarmeApiSDKLib\Models\CreateUsageRequest $body Request for creating a usage
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetUsageResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function createUsage(
-        string $subscriptionId,
-        string $itemId,
-        \PagarmeApiSDKLib\Models\CreateUsageRequest $body,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetUsageResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/items/{item_id}/usages';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-            'item_id'         => $itemId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($body);
-
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetUsageResponse');
     }
 
     /**
@@ -1225,75 +441,6 @@ class SubscriptionsController extends BaseController
     }
 
     /**
-     * @param string $subscriptionId
-     * @param \PagarmeApiSDKLib\Models\UpdateSubscriptionAffiliationIdRequest $request Request for
-     *        updating a subscription affiliation id
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function updateSubscriptionAffiliationId(
-        string $subscriptionId,
-        \PagarmeApiSDKLib\Models\UpdateSubscriptionAffiliationIdRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetSubscriptionResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/gateway-affiliation-id';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
-    }
-
-    /**
      * Updates the metadata from a subscription
      *
      * @param string $subscriptionId The subscription id
@@ -1432,31 +579,22 @@ class SubscriptionsController extends BaseController
     }
 
     /**
-     * @param string $subscriptionId Subscription Id
-     * @param string $page Page number
-     * @param string $size Page size
+     * Gets a subscription
      *
-     * @return \PagarmeApiSDKLib\Models\ListCyclesResponse Response from the API call
+     * @param string $subscriptionId Subscription id
+     *
+     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function getSubscriptionCycles(
-        string $subscriptionId,
-        string $page,
-        string $size
-    ): \PagarmeApiSDKLib\Models\ListCyclesResponse {
+    public function getSubscription(string $subscriptionId): \PagarmeApiSDKLib\Models\GetSubscriptionResponse
+    {
         //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/cycles';
+        $_queryBuilder = '/subscriptions/{subscription_id}';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
             'subscription_id' => $subscriptionId,
-        ]);
-
-        //process optional query parameters
-        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
-            'page'            => $page,
-            'size'            => $size,
         ]);
 
         //validate and preprocess url
@@ -1497,7 +635,364 @@ class SubscriptionsController extends BaseController
         //handle errors defined at the API level
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListCyclesResponse');
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
+    }
+
+    /**
+     * @param string $subscriptionId
+     * @param \PagarmeApiSDKLib\Models\UpdateCurrentCycleEndDateRequest $request Request for
+     *        updating the end date of the current signature cycle
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function updateLatestPeriodEndAt(
+        string $subscriptionId,
+        \PagarmeApiSDKLib\Models\UpdateCurrentCycleEndDateRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetSubscriptionResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/periods/latest/end-at';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
+    }
+
+    /**
+     * @param string $subscriptionId Subscription Id
+     * @param \PagarmeApiSDKLib\Models\UpdateCurrentCycleStatusRequest $request Request for updating
+     *        the end date of the subscription current status
+     * @param string|null $idempotencyKey
+     *
+     * @return void Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function updateCurrentCycleStatus(
+        string $subscriptionId,
+        \PagarmeApiSDKLib\Models\UpdateCurrentCycleStatusRequest $request,
+        ?string $idempotencyKey = null
+    ): void {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/cycle-status';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+    }
+
+    /**
+     * Get Subscription Items
+     *
+     * @param string $subscriptionId The subscription id
+     * @param int|null $page Page number
+     * @param int|null $size Page size
+     * @param string|null $name The item name
+     * @param string|null $code Identification code in the client system
+     * @param string|null $status The item statis
+     * @param string|null $description The item description
+     * @param string|null $createdSince Filter for item's creation date start range
+     * @param string|null $createdUntil Filter for item's creation date end range
+     *
+     * @return \PagarmeApiSDKLib\Models\ListSubscriptionItemsResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getSubscriptionItems(
+        string $subscriptionId,
+        ?int $page = null,
+        ?int $size = null,
+        ?string $name = null,
+        ?string $code = null,
+        ?string $status = null,
+        ?string $description = null,
+        ?string $createdSince = null,
+        ?string $createdUntil = null
+    ): \PagarmeApiSDKLib\Models\ListSubscriptionItemsResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/items';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+        ]);
+
+        //process optional query parameters
+        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
+            'page'            => $page,
+            'size'            => $size,
+            'name'            => $name,
+            'code'            => $code,
+            'status'          => $status,
+            'description'     => $description,
+            'created_since'   => $createdSince,
+            'created_until'   => $createdUntil,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListSubscriptionItemsResponse');
+    }
+
+    /**
+     * Get Subscription Item
+     *
+     * @param string $subscriptionId Subscription Id
+     * @param string $itemId Item id
+     *
+     * @return \PagarmeApiSDKLib\Models\GetSubscriptionItemResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getSubscriptionItem(
+        string $subscriptionId,
+        string $itemId
+    ): \PagarmeApiSDKLib\Models\GetSubscriptionItemResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/items/{item_id}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+            'item_id'         => $itemId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionItemResponse');
+    }
+
+    /**
+     * @param string $subscriptionId
+     * @param \PagarmeApiSDKLib\Models\UpdateSubscriptionAffiliationIdRequest $request Request for
+     *        updating a subscription affiliation id
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function updateSubscriptionAffiliationId(
+        string $subscriptionId,
+        \PagarmeApiSDKLib\Models\UpdateSubscriptionAffiliationIdRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetSubscriptionResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/gateway-affiliation-id';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
     }
 
     /**
@@ -1570,24 +1065,255 @@ class SubscriptionsController extends BaseController
     }
 
     /**
-     * Updates the billing date from a subscription
+     * Updates a subscription item
+     *
+     * @param string $subscriptionId Subscription Id
+     * @param string $itemId Item id
+     * @param \PagarmeApiSDKLib\Models\UpdateSubscriptionItemRequest $body Request for updating a
+     *        subscription item
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetSubscriptionItemResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function updateSubscriptionItem(
+        string $subscriptionId,
+        string $itemId,
+        \PagarmeApiSDKLib\Models\UpdateSubscriptionItemRequest $body,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetSubscriptionItemResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/items/{item_id}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+            'item_id'         => $itemId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($body);
+
+        $_httpRequest = new HttpRequest(HttpMethod::PUT, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::put($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionItemResponse');
+    }
+
+    /**
+     * Creates a new Subscription item
+     *
+     * @param string $subscriptionId Subscription id
+     * @param \PagarmeApiSDKLib\Models\CreateSubscriptionItemRequest $request Request for creating a
+     *        subscription item
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetSubscriptionItemResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function createSubscriptionItem(
+        string $subscriptionId,
+        \PagarmeApiSDKLib\Models\CreateSubscriptionItemRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetSubscriptionItemResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/items';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionItemResponse');
+    }
+
+    /**
+     * Lists all usages from a subscription item
      *
      * @param string $subscriptionId The subscription id
-     * @param \PagarmeApiSDKLib\Models\UpdateSubscriptionBillingDateRequest $request Request for
-     *        updating the subscription billing date
+     * @param string $itemId The subscription item id
+     * @param int|null $page Page number
+     * @param int|null $size Page size
+     * @param string|null $code Identification code in the client system
+     * @param string|null $group Identification group in the client system
+     * @param \DateTime|null $usedSince
+     * @param \DateTime|null $usedUntil
+     *
+     * @return \PagarmeApiSDKLib\Models\ListUsagesResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getUsages(
+        string $subscriptionId,
+        string $itemId,
+        ?int $page = null,
+        ?int $size = null,
+        ?string $code = null,
+        ?string $group = null,
+        ?\DateTime $usedSince = null,
+        ?\DateTime $usedUntil = null
+    ): \PagarmeApiSDKLib\Models\ListUsagesResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/items/{item_id}/usages';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+            'item_id'         => $itemId,
+        ]);
+
+        //process optional query parameters
+        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
+            'page'            => $page,
+            'size'            => $size,
+            'code'            => $code,
+            'group'           => $group,
+            'used_since'      => DateTimeHelper::toRfc3339DateTime($usedSince),
+            'used_until'      => DateTimeHelper::toRfc3339DateTime($usedUntil),
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListUsagesResponse');
+    }
+
+    /**
+     * Atualização do valor mínimo da assinatura
+     *
+     * @param string $subscriptionId Subscription Id
+     * @param \PagarmeApiSDKLib\Models\UpdateSubscriptionMinimumPriceRequest $request Request da
+     *        requisição com o valor mínimo que será configurado
      * @param string|null $idempotencyKey
      *
      * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
      *
      * @throws ApiException Thrown if API call fails
      */
-    public function updateSubscriptionBillingDate(
+    public function updateSubscriptionMiniumPrice(
         string $subscriptionId,
-        \PagarmeApiSDKLib\Models\UpdateSubscriptionBillingDateRequest $request,
+        \PagarmeApiSDKLib\Models\UpdateSubscriptionMinimumPriceRequest $request,
         ?string $idempotencyKey = null
     ): \PagarmeApiSDKLib\Models\GetSubscriptionResponse {
         //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/billing-date';
+        $_queryBuilder = '/subscriptions/{subscription_id}/minimum_price';
 
         //process optional query parameters
         $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
@@ -1621,6 +1347,206 @@ class SubscriptionsController extends BaseController
         // and invoke the API call request to fetch the response
         try {
             $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
+    }
+
+    /**
+     * @param string $subscriptionId The subscription id
+     * @param string $cycleId
+     *
+     * @return \PagarmeApiSDKLib\Models\GetPeriodResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getSubscriptionCycleById(
+        string $subscriptionId,
+        string $cycleId
+    ): \PagarmeApiSDKLib\Models\GetPeriodResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/cycles/{cycleId}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+            'cycleId'         => $cycleId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetPeriodResponse');
+    }
+
+    /**
+     * Create Usage
+     *
+     * @param string $subscriptionId Subscription id
+     * @param string $itemId Item id
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetUsageResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function createAnUsage(
+        string $subscriptionId,
+        string $itemId,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetUsageResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/items/{item_id}/usages';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+            'item_id'         => $itemId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetUsageResponse');
+    }
+
+    /**
+     * Cancels a subscription
+     *
+     * @param string $subscriptionId Subscription id
+     * @param \PagarmeApiSDKLib\Models\CreateCancelSubscriptionRequest|null $request Request for
+     *        cancelling a subscription
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function cancelSubscription(
+        string $subscriptionId,
+        ?\PagarmeApiSDKLib\Models\CreateCancelSubscriptionRequest $request = null,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetSubscriptionResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
         } catch (\Unirest\Exception $ex) {
             throw new ApiException($ex->getMessage(), $_httpRequest);
         }
@@ -1847,6 +1773,573 @@ class SubscriptionsController extends BaseController
     }
 
     /**
+     * Updates the credit card from a subscription
+     *
+     * @param string $subscriptionId Subscription id
+     * @param \PagarmeApiSDKLib\Models\UpdateSubscriptionCardRequest $request Request for updating a
+     *        card
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function updateSubscriptionCard(
+        string $subscriptionId,
+        \PagarmeApiSDKLib\Models\UpdateSubscriptionCardRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetSubscriptionResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/card';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
+    }
+
+    /**
+     * Deletes a usage
+     *
+     * @param string $subscriptionId The subscription id
+     * @param string $itemId The subscription item id
+     * @param string $usageId The usage id
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetUsageResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function deleteUsage(
+        string $subscriptionId,
+        string $itemId,
+        string $usageId,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetUsageResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/items/{item_id}/usages/{usage_id}';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+            'item_id'         => $itemId,
+            'usage_id'        => $usageId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::delete($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetUsageResponse');
+    }
+
+    /**
+     * Creates a discount
+     *
+     * @param string $subscriptionId Subscription id
+     * @param \PagarmeApiSDKLib\Models\CreateDiscountRequest $request Request for creating a
+     *        discount
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetDiscountResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function createDiscount(
+        string $subscriptionId,
+        \PagarmeApiSDKLib\Models\CreateDiscountRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetDiscountResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/discounts';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetDiscountResponse');
+    }
+
+    /**
+     * Updates the payment method from a subscription
+     *
+     * @param string $subscriptionId Subscription id
+     * @param \PagarmeApiSDKLib\Models\UpdateSubscriptionPaymentMethodRequest $request Request for
+     *        updating the paymentmethod from a subscription
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function updateSubscriptionPaymentMethod(
+        string $subscriptionId,
+        \PagarmeApiSDKLib\Models\UpdateSubscriptionPaymentMethodRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetSubscriptionResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/payment-method';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
+    }
+
+    /**
+     * Creates a increment
+     *
+     * @param string $subscriptionId Subscription id
+     * @param \PagarmeApiSDKLib\Models\CreateIncrementRequest $request Request for creating a
+     *        increment
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetIncrementResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function createIncrement(
+        string $subscriptionId,
+        \PagarmeApiSDKLib\Models\CreateIncrementRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetIncrementResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/increments';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetIncrementResponse');
+    }
+
+    /**
+     * Creates a usage
+     *
+     * @param string $subscriptionId Subscription Id
+     * @param string $itemId Item id
+     * @param \PagarmeApiSDKLib\Models\CreateUsageRequest $body Request for creating a usage
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetUsageResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function createUsage(
+        string $subscriptionId,
+        string $itemId,
+        \PagarmeApiSDKLib\Models\CreateUsageRequest $body,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetUsageResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/items/{item_id}/usages';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+            'item_id'         => $itemId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($body);
+
+        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetUsageResponse');
+    }
+
+    /**
+     * @param string $subscriptionId Subscription Id
+     * @param string $page Page number
+     * @param string $size Page size
+     *
+     * @return \PagarmeApiSDKLib\Models\ListCyclesResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getSubscriptionCycles(
+        string $subscriptionId,
+        string $page,
+        string $size
+    ): \PagarmeApiSDKLib\Models\ListCyclesResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/cycles';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+        ]);
+
+        //process optional query parameters
+        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
+            'page'            => $page,
+            'size'            => $size,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListCyclesResponse');
+    }
+
+    /**
+     * Updates the billing date from a subscription
+     *
+     * @param string $subscriptionId The subscription id
+     * @param \PagarmeApiSDKLib\Models\UpdateSubscriptionBillingDateRequest $request Request for
+     *        updating the subscription billing date
+     * @param string|null $idempotencyKey
+     *
+     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function updateSubscriptionBillingDate(
+        string $subscriptionId,
+        \PagarmeApiSDKLib\Models\UpdateSubscriptionBillingDateRequest $request,
+        ?string $idempotencyKey = null
+    ): \PagarmeApiSDKLib\Models\GetSubscriptionResponse {
+        //prepare query string for API call
+        $_queryBuilder = '/subscriptions/{subscription_id}/billing-date';
+
+        //process optional query parameters
+        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
+            'subscription_id' => $subscriptionId,
+        ]);
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json',
+            'content-type'  => 'application/json',
+            'idempotency-key' => $idempotencyKey
+        ];
+
+        //json encode body
+        $_bodyJson = Request\Body::Json($request);
+
+        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
+    }
+
+    /**
      * Updates the start at date from a subscription
      *
      * @param string $subscriptionId The subscription id
@@ -1915,499 +2408,6 @@ class SubscriptionsController extends BaseController
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
         return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
-    }
-
-    /**
-     * Updates a subscription item
-     *
-     * @param string $subscriptionId Subscription Id
-     * @param string $itemId Item id
-     * @param \PagarmeApiSDKLib\Models\UpdateSubscriptionItemRequest $body Request for updating a
-     *        subscription item
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetSubscriptionItemResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function updateSubscriptionItem(
-        string $subscriptionId,
-        string $itemId,
-        \PagarmeApiSDKLib\Models\UpdateSubscriptionItemRequest $body,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetSubscriptionItemResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/items/{item_id}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-            'item_id'         => $itemId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($body);
-
-        $_httpRequest = new HttpRequest(HttpMethod::PUT, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::put($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionItemResponse');
-    }
-
-    /**
-     * Creates a new Subscription item
-     *
-     * @param string $subscriptionId Subscription id
-     * @param \PagarmeApiSDKLib\Models\CreateSubscriptionItemRequest $request Request for creating a
-     *        subscription item
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetSubscriptionItemResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function createSubscriptionItem(
-        string $subscriptionId,
-        \PagarmeApiSDKLib\Models\CreateSubscriptionItemRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetSubscriptionItemResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/items';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::POST, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::post($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionItemResponse');
-    }
-
-    /**
-     * Gets a subscription
-     *
-     * @param string $subscriptionId Subscription id
-     *
-     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getSubscription(string $subscriptionId): \PagarmeApiSDKLib\Models\GetSubscriptionResponse
-    {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
-    }
-
-    /**
-     * Lists all usages from a subscription item
-     *
-     * @param string $subscriptionId The subscription id
-     * @param string $itemId The subscription item id
-     * @param int|null $page Page number
-     * @param int|null $size Page size
-     * @param string|null $code Identification code in the client system
-     * @param string|null $group Identification group in the client system
-     * @param \DateTime|null $usedSince
-     * @param \DateTime|null $usedUntil
-     *
-     * @return \PagarmeApiSDKLib\Models\ListUsagesResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getUsages(
-        string $subscriptionId,
-        string $itemId,
-        ?int $page = null,
-        ?int $size = null,
-        ?string $code = null,
-        ?string $group = null,
-        ?\DateTime $usedSince = null,
-        ?\DateTime $usedUntil = null
-    ): \PagarmeApiSDKLib\Models\ListUsagesResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/items/{item_id}/usages';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-            'item_id'         => $itemId,
-        ]);
-
-        //process optional query parameters
-        ApiHelper::appendUrlWithQueryParameters($_queryBuilder, [
-            'page'            => $page,
-            'size'            => $size,
-            'code'            => $code,
-            'group'           => $group,
-            'used_since'      => DateTimeHelper::toRfc3339DateTime($usedSince),
-            'used_until'      => DateTimeHelper::toRfc3339DateTime($usedUntil),
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListUsagesResponse');
-    }
-
-    /**
-     * @param string $subscriptionId
-     * @param \PagarmeApiSDKLib\Models\UpdateCurrentCycleEndDateRequest $request Request for
-     *        updating the end date of the current signature cycle
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function updateLatestPeriodEndAt(
-        string $subscriptionId,
-        \PagarmeApiSDKLib\Models\UpdateCurrentCycleEndDateRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetSubscriptionResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/periods/latest/end-at';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
-    }
-
-    /**
-     * Atualização do valor mínimo da assinatura
-     *
-     * @param string $subscriptionId Subscription Id
-     * @param \PagarmeApiSDKLib\Models\UpdateSubscriptionMinimumPriceRequest $request Request da
-     *        requisição com o valor mínimo que será configurado
-     * @param string|null $idempotencyKey
-     *
-     * @return \PagarmeApiSDKLib\Models\GetSubscriptionResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function updateSubscriptionMiniumPrice(
-        string $subscriptionId,
-        \PagarmeApiSDKLib\Models\UpdateSubscriptionMinimumPriceRequest $request,
-        ?string $idempotencyKey = null
-    ): \PagarmeApiSDKLib\Models\GetSubscriptionResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/minimum_price';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json',
-            'content-type'  => 'application/json',
-            'idempotency-key' => $idempotencyKey
-        ];
-
-        //json encode body
-        $_bodyJson = Request\Body::Json($request);
-
-        $_httpRequest = new HttpRequest(HttpMethod::PATCH, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::patch($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders(), $_bodyJson);
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetSubscriptionResponse');
-    }
-
-    /**
-     * @param string $subscriptionId The subscription id
-     * @param string $cycleId
-     *
-     * @return \PagarmeApiSDKLib\Models\GetPeriodResponse Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getSubscriptionCycleById(
-        string $subscriptionId,
-        string $cycleId
-    ): \PagarmeApiSDKLib\Models\GetPeriodResponse {
-        //prepare query string for API call
-        $_queryBuilder = '/subscriptions/{subscription_id}/cycles/{cycleId}';
-
-        //process optional query parameters
-        $_queryBuilder = ApiHelper::appendUrlWithTemplateParameters($_queryBuilder, [
-            'subscription_id' => $subscriptionId,
-            'cycleId'         => $cycleId,
-        ]);
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetPeriodResponse');
     }
 
     /**

--- a/src/Controllers/TransfersController.php
+++ b/src/Controllers/TransfersController.php
@@ -28,6 +28,59 @@ class TransfersController extends BaseController
     }
 
     /**
+     * Gets all transfers
+     *
+     * @return \PagarmeApiSDKLib\Models\ListTransfers Response from the API call
+     *
+     * @throws ApiException Thrown if API call fails
+     */
+    public function getTransfers(): \PagarmeApiSDKLib\Models\ListTransfers
+    {
+        //prepare query string for API call
+        $_queryBuilder = '/transfers';
+
+        //validate and preprocess url
+        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
+
+        //prepare headers
+        $_headers = [
+            'user-agent'    => self::$userAgent,
+            'Accept'        => 'application/json'
+        ];
+
+        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
+
+        // Apply authorization to request
+        $this->getAuthManager('global')->apply($_httpRequest);
+
+        //call on-before Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
+        }
+
+        // and invoke the API call request to fetch the response
+        try {
+            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
+        } catch (\Unirest\Exception $ex) {
+            throw new ApiException($ex->getMessage(), $_httpRequest);
+        }
+
+
+        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
+        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
+
+        //call on-after Http callback
+        if ($this->getHttpCallBack() != null) {
+            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
+        }
+
+        //handle errors defined at the API level
+        $this->validateResponse($_httpResponse, $_httpRequest);
+        $mapper = $this->getJsonMapper();
+        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListTransfers');
+    }
+
+    /**
      * @param string $transferId
      *
      * @return \PagarmeApiSDKLib\Models\GetTransfer Response from the API call
@@ -141,58 +194,5 @@ class TransfersController extends BaseController
         $this->validateResponse($_httpResponse, $_httpRequest);
         $mapper = $this->getJsonMapper();
         return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\GetTransfer');
-    }
-
-    /**
-     * Gets all transfers
-     *
-     * @return \PagarmeApiSDKLib\Models\ListTransfers Response from the API call
-     *
-     * @throws ApiException Thrown if API call fails
-     */
-    public function getTransfers(): \PagarmeApiSDKLib\Models\ListTransfers
-    {
-        //prepare query string for API call
-        $_queryBuilder = '/transfers';
-
-        //validate and preprocess url
-        $_queryUrl = ApiHelper::cleanUrl($this->config->getBaseUri() . $_queryBuilder);
-
-        //prepare headers
-        $_headers = [
-            'user-agent'    => self::$userAgent,
-            'Accept'        => 'application/json'
-        ];
-
-        $_httpRequest = new HttpRequest(HttpMethod::GET, $_headers, $_queryUrl);
-
-        // Apply authorization to request
-        $this->getAuthManager('global')->apply($_httpRequest);
-
-        //call on-before Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
-        }
-
-        // and invoke the API call request to fetch the response
-        try {
-            $response = Request::get($_httpRequest->getQueryUrl(), $_httpRequest->getHeaders());
-        } catch (\Unirest\Exception $ex) {
-            throw new ApiException($ex->getMessage(), $_httpRequest);
-        }
-
-
-        $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
-        $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
-
-        //call on-after Http callback
-        if ($this->getHttpCallBack() != null) {
-            $this->getHttpCallBack()->callOnAfterRequest($_httpContext);
-        }
-
-        //handle errors defined at the API level
-        $this->validateResponse($_httpResponse, $_httpRequest);
-        $mapper = $this->getJsonMapper();
-        return $mapper->mapClass($response->body, 'PagarmeApiSDKLib\\Models\\ListTransfers');
     }
 }

--- a/src/Models/CreateOrderItemRequest.php
+++ b/src/Models/CreateOrderItemRequest.php
@@ -33,16 +33,6 @@ class CreateOrderItemRequest implements \JsonSerializable
     private $quantity;
 
     /**
-     * @var CreateSellerRequest|null
-     */
-    private $seller;
-
-    /**
-     * @var string|null
-     */
-    private $sellerId;
-
-    /**
      * @var string
      */
     private $category;
@@ -136,50 +126,6 @@ class CreateOrderItemRequest implements \JsonSerializable
     }
 
     /**
-     * Returns Seller.
-     *
-     * Item seller
-     */
-    public function getSeller(): ?CreateSellerRequest
-    {
-        return $this->seller;
-    }
-
-    /**
-     * Sets Seller.
-     *
-     * Item seller
-     *
-     * @maps seller
-     */
-    public function setSeller(?CreateSellerRequest $seller): void
-    {
-        $this->seller = $seller;
-    }
-
-    /**
-     * Returns Seller Id.
-     *
-     * seller identificator
-     */
-    public function getSellerId(): ?string
-    {
-        return $this->sellerId;
-    }
-
-    /**
-     * Sets Seller Id.
-     *
-     * seller identificator
-     *
-     * @maps seller_id
-     */
-    public function setSellerId(?string $sellerId): void
-    {
-        $this->sellerId = $sellerId;
-    }
-
-    /**
      * Returns Category.
      *
      * Category
@@ -235,18 +181,12 @@ class CreateOrderItemRequest implements \JsonSerializable
     public function jsonSerialize(bool $asArrayWhenEmpty = false)
     {
         $json = [];
-        $json['amount']        = $this->amount;
-        $json['description']   = $this->description;
-        $json['quantity']      = $this->quantity;
-        if (isset($this->seller)) {
-            $json['seller']    = $this->seller;
-        }
-        if (isset($this->sellerId)) {
-            $json['seller_id'] = $this->sellerId;
-        }
-        $json['category']      = $this->category;
+        $json['amount']      = $this->amount;
+        $json['description'] = $this->description;
+        $json['quantity']    = $this->quantity;
+        $json['category']    = $this->category;
         if (isset($this->code)) {
-            $json['code']      = $this->code;
+            $json['code']    = $this->code;
         }
 
         return (!$asArrayWhenEmpty && empty($json)) ? new stdClass() : $json;

--- a/src/Models/GetOrderItemResponse.php
+++ b/src/Models/GetOrderItemResponse.php
@@ -38,11 +38,6 @@ class GetOrderItemResponse implements \JsonSerializable
     private $quantity;
 
     /**
-     * @var GetSellerResponse|null
-     */
-    private $getSellerResponse;
-
-    /**
      * @var string
      */
     private $category;
@@ -157,28 +152,6 @@ class GetOrderItemResponse implements \JsonSerializable
     }
 
     /**
-     * Returns Get Seller Response.
-     *
-     * Seller data
-     */
-    public function getGetSellerResponse(): ?GetSellerResponse
-    {
-        return $this->getSellerResponse;
-    }
-
-    /**
-     * Sets Get Seller Response.
-     *
-     * Seller data
-     *
-     * @maps GetSellerResponse
-     */
-    public function setGetSellerResponse(?GetSellerResponse $getSellerResponse): void
-    {
-        $this->getSellerResponse = $getSellerResponse;
-    }
-
-    /**
      * Returns Category.
      *
      * Category
@@ -235,15 +208,12 @@ class GetOrderItemResponse implements \JsonSerializable
     public function jsonSerialize(bool $asArrayWhenEmpty = false)
     {
         $json = [];
-        $json['id']                    = $this->id;
-        $json['amount']                = $this->amount;
-        $json['description']           = $this->description;
-        $json['quantity']              = $this->quantity;
-        if (isset($this->getSellerResponse)) {
-            $json['GetSellerResponse'] = $this->getSellerResponse;
-        }
-        $json['category']              = $this->category;
-        $json['code']                  = $this->code;
+        $json['id']          = $this->id;
+        $json['amount']      = $this->amount;
+        $json['description'] = $this->description;
+        $json['quantity']    = $this->quantity;
+        $json['category']    = $this->category;
+        $json['code']        = $this->code;
 
         return (!$asArrayWhenEmpty && empty($json)) ? new stdClass() : $json;
     }

--- a/src/PagarmeApiSDKClient.php
+++ b/src/PagarmeApiSDKClient.php
@@ -17,16 +17,15 @@ use PagarmeApiSDKLib\Controllers;
  */
 class PagarmeApiSDKClient implements ConfigurationInterface
 {
+    private $orders;
     private $plans;
     private $subscriptions;
     private $invoices;
-    private $orders;
     private $customers;
     private $recipients;
     private $charges;
-    private $transfers;
     private $tokens;
-    private $sellers;
+    private $transfers;
     private $transactions;
 
     private $timeout = ConfigurationDefaults::TIMEOUT;
@@ -217,6 +216,21 @@ class PagarmeApiSDKClient implements ConfigurationInterface
     }
 
     /**
+     * Returns Orders Controller
+     */
+    public function getOrdersController(): Controllers\OrdersController
+    {
+        if ($this->orders == null) {
+            $this->orders = new Controllers\OrdersController(
+                $this,
+                $this->authManagers,
+                $this->httpCallback
+            );
+        }
+        return $this->orders;
+    }
+
+    /**
      * Returns Plans Controller
      */
     public function getPlansController(): Controllers\PlansController
@@ -255,21 +269,6 @@ class PagarmeApiSDKClient implements ConfigurationInterface
             );
         }
         return $this->invoices;
-    }
-
-    /**
-     * Returns Orders Controller
-     */
-    public function getOrdersController(): Controllers\OrdersController
-    {
-        if ($this->orders == null) {
-            $this->orders = new Controllers\OrdersController(
-                $this,
-                $this->authManagers,
-                $this->httpCallback
-            );
-        }
-        return $this->orders;
     }
 
     /**
@@ -318,21 +317,6 @@ class PagarmeApiSDKClient implements ConfigurationInterface
     }
 
     /**
-     * Returns Transfers Controller
-     */
-    public function getTransfersController(): Controllers\TransfersController
-    {
-        if ($this->transfers == null) {
-            $this->transfers = new Controllers\TransfersController(
-                $this,
-                $this->authManagers,
-                $this->httpCallback
-            );
-        }
-        return $this->transfers;
-    }
-
-    /**
      * Returns Tokens Controller
      */
     public function getTokensController(): Controllers\TokensController
@@ -348,18 +332,18 @@ class PagarmeApiSDKClient implements ConfigurationInterface
     }
 
     /**
-     * Returns Sellers Controller
+     * Returns Transfers Controller
      */
-    public function getSellersController(): Controllers\SellersController
+    public function getTransfersController(): Controllers\TransfersController
     {
-        if ($this->sellers == null) {
-            $this->sellers = new Controllers\SellersController(
+        if ($this->transfers == null) {
+            $this->transfers = new Controllers\TransfersController(
                 $this,
                 $this->authManagers,
                 $this->httpCallback
             );
         }
-        return $this->sellers;
+        return $this->transfers;
     }
 
     /**


### PR DESCRIPTION
The customer should no longer use the Mark1 Sellers endpoint as it is outdated. We need to remove it from the SDK so it no longer has access.